### PR TITLE
Compute listing source counts, improve profile identity resolution, add Supabase client and roadmap

### DIFF
--- a/api/get-dashboard-summary.js
+++ b/api/get-dashboard-summary.js
@@ -1068,6 +1068,14 @@ export default async function handler(req, res) {
       totalMessages: computed.total_messages
     });
 
+    const listingSourceCounts = rows.reduce((acc, row) => {
+      const source = clean(row?.source_table || '');
+      if (source === 'user_listings') acc.user_listings += 1;
+      else if (source === 'listings') acc.listings += 1;
+      else acc.other += 1;
+      return acc;
+    }, { user_listings: 0, listings: 0, other: 0 });
+
     const recentListings = rows.slice(0, 12).map((row) => ({
       id: row.id,
       title: row.title,
@@ -1168,9 +1176,10 @@ export default async function handler(req, res) {
           needs_action_count: computed.needs_action_count,
           lifecycle_updated_at: clean(snapshot.lifecycle_updated_at || ''),
           source_counts: {
-            user_listings: userListingRows.length,
-            listings: legacyListingRows.length,
-            merged: rows.length
+            user_listings: listingSourceCounts.user_listings,
+            listings: listingSourceCounts.listings,
+            merged: rows.length,
+            other: listingSourceCounts.other
           }
         },
         recent_activity: recentListings.slice(0, 8).map((row) => ({
@@ -1189,9 +1198,10 @@ export default async function handler(req, res) {
           snapshot_active_listings: safeNumber(snapshot.active_listings ?? computed.active_listings, 0),
           lifecycle_updated_at: clean(snapshot.lifecycle_updated_at || ''),
           sources: {
-            user_listings: userListingRows.length,
-            listings: legacyListingRows.length,
-            merged: rows.length
+            user_listings: listingSourceCounts.user_listings,
+            listings: listingSourceCounts.listings,
+            merged: rows.length,
+            other: listingSourceCounts.other
           }
         },
         account_snapshot: {

--- a/api/profile.js
+++ b/api/profile.js
@@ -1,4 +1,5 @@
 import { supabase } from '../lib/supabase.js';
+import { randomUUID } from 'node:crypto';
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
@@ -30,6 +31,7 @@ export default async function handler(req, res) {
   }
 
   // Fallback: email from query or body
+  const requestedId = req.query.id || req.body?.id || req.body?.user_id || null;
   if (!email) {
     email = req.query.email || req.body?.email;
   }
@@ -49,6 +51,8 @@ export default async function handler(req, res) {
 
     if (authUid) {
       query = query.eq('id', authUid);
+    } else if (requestedId) {
+      query = query.eq('id', requestedId);
     } else {
       query = query.ilike('email', email);
     }
@@ -115,7 +119,7 @@ export default async function handler(req, res) {
           .ilike('email', email)
           .maybeSingle();
 
-        const profileId = userRow?.auth_user_id || crypto.randomUUID();
+        const profileId = userRow?.auth_user_id || requestedId || randomUUID();
         upsertData = { id: profileId, email, ...updates };
       }
     }

--- a/docs/testing-fix-roadmap.md
+++ b/docs/testing-fix-roadmap.md
@@ -1,0 +1,70 @@
+# Dashboard Reliability Roadmap (10 Phases)
+
+## Constraints
+- Keep the API surface at **12 endpoints max**; prefer extending existing responses over adding endpoints.
+- Prioritize the current blocker: **profile info not syncing from Supabase into the client dashboard**.
+
+## Phase 1 — Stabilize summary payloads (immediate)
+- Fix server-side runtime breakers in `/api/get-dashboard-summary` so the dashboard always receives a valid payload.
+- Add source-count safeguards so merged listing stats never reference undefined variables.
+- Outcome: dashboard boot path no longer silently falls back due to 500s.
+
+## Phase 2 — Establish profile source of truth
+- Make `profiles` table the canonical write/read layer for dashboard profile fields.
+- Ensure `/api/profile` GET and POST return a consistent shape (`{ profile }` and `updated_at`).
+- Remove field drift between `account_snapshot`, `profile_snapshot`, and localStorage fallback.
+
+## Phase 3 — Identity hardening for sync correctness
+- Enforce user resolution precedence as: verified auth UID -> users.id -> normalized email fallback.
+- Audit all profile/account endpoints to ensure same identity strategy (no mixed casing or alternate email aliases).
+- Add debug markers to responses (`identity_source`, `matched_by`) for faster triage.
+
+## Phase 4 — Client hydration determinism
+- Refactor dashboard boot sequence to hydrate profile in one deterministic pass:
+  1. session,
+  2. account/session summary,
+  3. profile,
+  4. render.
+- Prevent stale local snapshot from overriding fresh Supabase profile unless API fails.
+- Add explicit "remote vs local" status message in setup panel.
+
+## Phase 5 — Write-path verification and optimistic UI
+- After profile save, re-read server profile and diff returned fields against form values.
+- Surface field-level sync errors (e.g., invalid URL normalization, missing write permissions).
+- Keep optimistic UI but rollback individual fields when server rejects updates.
+
+## Phase 6 — Database and RLS validation
+- Verify Supabase RLS allows authenticated users to read/write their own profile row by `id` and intended email fallback logic.
+- Confirm indexes for `profiles.id`, `profiles.email`, `subscriptions.user_id`, `posting_usage(user_id,date_key)`.
+- Add migration notes for required nullable/non-null profile fields.
+
+## Phase 7 — Observability and diagnostics
+- Add structured logs for dashboard-critical endpoints (`profile`, `extension-state`, `get-dashboard-summary`) with request IDs.
+- Add lightweight sync diagnostics in UI (last profile sync timestamp + source endpoint).
+- Create a reproducible "profile sync smoke test" script for local and production checks.
+
+## Phase 8 — API budget and consolidation (12 max)
+- Keep current 12 APIs; do not add net-new endpoints.
+- Consolidate overlapping data inside existing endpoints:
+  - `/api/get-dashboard-summary` as main read aggregator,
+  - `/api/profile` as profile write/read,
+  - `/api/extension-state` for extension compatibility only.
+- De-duplicate repeated subscription/profile fetch logic in shared helpers.
+
+## Phase 9 — Automated test coverage
+- Add integration tests for:
+  - profile save -> reload -> dashboard render roundtrip,
+  - UID-based identity and email fallback behavior,
+  - no-regression for account snapshot/profile snapshot hydration.
+- Add contract tests asserting required response keys used by `dashboard.js`.
+
+## Phase 10 — Performance + rollout safety
+- Introduce staged rollout flags for sync-path changes.
+- Add cache-busting controls only where needed (`_ts`) and avoid over-fetching on routine navigation.
+- Define rollback playbook and owner checklist for production incident handling.
+
+## Immediate next execution order
+1. Phase 1 + Phase 4 smoke validation.
+2. Phase 2 + Phase 3 identity/profile normalization.
+3. Phase 5 + Phase 7 visibility improvements.
+4. Phase 9 tests before broader refactors in Phase 8/10.

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables.');
+}
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false
+  }
+});


### PR DESCRIPTION
### Motivation
- Prevent runtime failures in the dashboard summary by removing references to potentially undefined listing arrays and provide deterministic source counts. 
- Improve profile GET/POST identity resolution so profile writes/reads can succeed when no auth token is present and a client-provided id is available. 
- Centralize Supabase client creation to ensure the service-role client is available and validated at runtime. 
- Add a short-term roadmap for stabilizing dashboard/profile sync and testing.

### Description
- Added a `listingSourceCounts` reducer in `api/get-dashboard-summary.js` to compute `user_listings`, `listings`, and `other` counts from `rows` and replaced previous references to `userListingRows`/`legacyListingRows` with these safe counts. 
- Included the `other` bucket in both `lifecycle_tracking.source_counts` and `listing_data_state.sources` in `api/get-dashboard-summary.js`. 
- In `api/profile.js` imported `randomUUID` from `node:crypto`, introduced `requestedId` from query/body, and used `requestedId` in GET lookups and as a fallback profile id in POST upserts instead of relying on `crypto.randomUUID()`. 
- Added a new `lib/supabase.js` that creates and exports a Supabase client using `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` environment variables and throws if they are missing. 
- Added `docs/testing-fix-roadmap.md` with a 10-phase plan to stabilize dashboard payloads, profile sync, identity hardening, observability, and tests.

### Testing
- No automated tests were executed as part of this change.
- Changes are limited to server-side request handlers and a new client module and should be validated by integration/smoke tests for `/api/get-dashboard-summary` and `/api/profile` in follow-up work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc92600a5083259683ea3ad9bd7de9)