### PR TITLE
Add request IDs & debug, normalize identity/profile handling, access override, and dashboard summary fixes

### DIFF
--- a/api/create-billing-portal-session.js
+++ b/api/create-billing-portal-session.js
@@ -1,5 +1,6 @@
 import Stripe from "stripe";
 import { createClient } from "@supabase/supabase-js";
+import { randomUUID } from "node:crypto";
 import { requireVerifiedDashboardUser, getTrustedIdentity } from "./_shared/auth.js";
 
 function getStripeClient() {
@@ -342,8 +343,11 @@ async function customerHasManageableSubscription(stripeClient, customerId, mirro
 }
 
 export default async function handler(req, res) {
+  const requestId = randomUUID();
+  res.setHeader("x-request-id", requestId);
+
   if (req.method !== "POST") {
-    return json(res, 405, { error: "Method not allowed" });
+    return json(res, 405, { error: "Method not allowed", request_id: requestId });
   }
 
   try {
@@ -351,7 +355,7 @@ export default async function handler(req, res) {
 
     const body = parseBody(req);
     if (body.__parse_error) {
-      return json(res, 400, { error: body.__parse_error });
+      return json(res, 400, { error: body.__parse_error, request_id: requestId });
     }
 
     const verifiedUser = await requireVerifiedDashboardUser(req, res);
@@ -378,7 +382,8 @@ export default async function handler(req, res) {
       return json(res, 200, {
         redirectToCheckout: true,
         message: "Billing profile not active yet. Start checkout first.",
-        checkoutContext
+        checkoutContext,
+        request_id: requestId
       });
     }
 
@@ -393,7 +398,8 @@ export default async function handler(req, res) {
       return json(res, 200, {
         redirectToCheckout: true,
         message: "Stripe customer found, but no active plan is attached yet. Start checkout to activate billing.",
-        checkoutContext
+        checkoutContext,
+        request_id: requestId
       });
     }
 
@@ -403,13 +409,15 @@ export default async function handler(req, res) {
     });
 
     return json(res, 200, {
-      url: session.url
+      url: session.url,
+      request_id: requestId
     });
   } catch (error) {
     console.error("[billing-portal] fatal error:", error);
 
     return json(res, 500, {
-      error: error?.message || "Failed to create billing portal session"
+      error: error?.message || "Failed to create billing portal session",
+      request_id: requestId
     });
   }
 }

--- a/api/extension-state.js
+++ b/api/extension-state.js
@@ -1,5 +1,15 @@
 import { supabase } from '../lib/supabase.js';
 
+const ACCESS_OVERRIDE_EMAILS = new Set(['damian044@icloud.com']);
+
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function normalizeEmail(value) {
+  return clean(value).toLowerCase();
+}
+
 const CORS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, OPTIONS',
@@ -19,7 +29,7 @@ export default async function handler(req, res) {
 
   // Accept Bearer token or ?email= param
   let authUid = null;
-  let email = req.query.email?.toLowerCase();
+  let email = normalizeEmail(req.query.email);
 
   const authHeader = req.headers.authorization || '';
   if (authHeader.startsWith('Bearer ')) {
@@ -27,7 +37,7 @@ export default async function handler(req, res) {
     const { data: { user }, error } = await supabase.auth.getUser(token);
     if (!error && user) {
       authUid = user.id;
-      email = user.email?.toLowerCase();
+      email = normalizeEmail(user.email);
     }
   }
 
@@ -66,14 +76,16 @@ export default async function handler(req, res) {
     const { data: usage } = await usageQuery.maybeSingle();
 
     // 4. Determine access
+    const forcedAccess = ACCESS_OVERRIDE_EMAILS.has(normalizeEmail(email));
     const isActive =
+      forcedAccess ||
       subscription?.is_active ||
       subscription?.access_active ||
       subscription?.bridge_access ||
       subscription?.subscription_status === 'active' ||
       subscription?.subscription_status === 'trialing';
 
-    const dailyLimit = subscription?.daily_posting_limit || 5;
+    const dailyLimit = forcedAccess ? 25 : (subscription?.daily_posting_limit || 5);
     const postsToday = usage?.posts_today || 0;
     const canPost = isActive && postsToday < dailyLimit;
 
@@ -81,8 +93,8 @@ export default async function handler(req, res) {
       success: true,
       profile: profile || null,
       subscription: {
-        status: subscription?.subscription_status || 'none',
-        plan: subscription?.plan_type || 'Beta',
+        status: forcedAccess ? 'active' : (subscription?.subscription_status || 'none'),
+        plan: forcedAccess ? 'Pro' : (subscription?.plan_type || 'Beta'),
         isActive,
         dailyLimit,
         postsToday,

--- a/api/get-dashboard-summary.js
+++ b/api/get-dashboard-summary.js
@@ -949,8 +949,10 @@ export default async function handler(req, res) {
     ]);
     const computed = buildComputedSummary(rows);
     const snapshot = subscriptionRow?.account_snapshot && typeof subscriptionRow.account_snapshot === 'object' ? subscriptionRow.account_snapshot : {};
-    const planValue = clean(subscriptionRow?.plan_type || subscriptionRow?.plan_name || subscriptionRow?.plan || user?.plan || user?.user_type || 'Founder Beta');
     const forcedAccess = hasTestingLimitOverride(finalEmail);
+    const planValue = forcedAccess
+      ? 'Pro'
+      : clean(subscriptionRow?.plan_type || subscriptionRow?.plan_name || subscriptionRow?.plan || user?.plan || user?.user_type || 'Founder Beta');
     const configuredLimit = safeNumber(snapshot.posting_limit ?? subscriptionRow?.daily_posting_limit ?? subscriptionRow?.posting_limit ?? inferPostingLimitFromPlan(planValue), inferPostingLimitFromPlan(planValue));
     const dailyLimit = forcedAccess ? 25 : configuredLimit;
     const usageToday = Math.max(safeNumber(postingUsageRow?.posts_today ?? postingUsageRow?.posts_used ?? postingUsageRow?.used_today, 0), safeNumber(snapshot.posts_today ?? snapshot.posts_used_today, 0), safeNumber(computed.posts_today, 0));
@@ -1068,6 +1070,14 @@ export default async function handler(req, res) {
       totalMessages: computed.total_messages
     });
 
+    const listingSourceCounts = rows.reduce((acc, row) => {
+      const source = clean(row?.source_table || '');
+      if (source === 'user_listings') acc.user_listings += 1;
+      else if (source === 'listings') acc.listings += 1;
+      else acc.other += 1;
+      return acc;
+    }, { user_listings: 0, listings: 0, other: 0 });
+
     const recentListings = rows.slice(0, 12).map((row) => ({
       id: row.id,
       title: row.title,
@@ -1168,9 +1178,10 @@ export default async function handler(req, res) {
           needs_action_count: computed.needs_action_count,
           lifecycle_updated_at: clean(snapshot.lifecycle_updated_at || ''),
           source_counts: {
-            user_listings: userListingRows.length,
-            listings: legacyListingRows.length,
-            merged: rows.length
+            user_listings: listingSourceCounts.user_listings,
+            listings: listingSourceCounts.listings,
+            merged: rows.length,
+            other: listingSourceCounts.other
           }
         },
         recent_activity: recentListings.slice(0, 8).map((row) => ({
@@ -1189,9 +1200,10 @@ export default async function handler(req, res) {
           snapshot_active_listings: safeNumber(snapshot.active_listings ?? computed.active_listings, 0),
           lifecycle_updated_at: clean(snapshot.lifecycle_updated_at || ''),
           sources: {
-            user_listings: userListingRows.length,
-            listings: legacyListingRows.length,
-            merged: rows.length
+            user_listings: listingSourceCounts.user_listings,
+            listings: listingSourceCounts.listings,
+            merged: rows.length,
+            other: listingSourceCounts.other
           }
         },
         account_snapshot: {

--- a/api/profile.js
+++ b/api/profile.js
@@ -1,4 +1,5 @@
 import { supabase } from '../lib/supabase.js';
+import { randomUUID } from 'node:crypto';
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
@@ -30,6 +31,7 @@ export default async function handler(req, res) {
   }
 
   // Fallback: email from query or body
+  const requestedId = req.query.id || req.body?.id || req.body?.user_id || null;
   if (!email) {
     email = req.query.email || req.body?.email;
   }
@@ -49,6 +51,8 @@ export default async function handler(req, res) {
 
     if (authUid) {
       query = query.eq('id', authUid);
+    } else if (requestedId) {
+      query = query.eq('id', requestedId);
     } else {
       query = query.ilike('email', email);
     }
@@ -115,7 +119,7 @@ export default async function handler(req, res) {
           .ilike('email', email)
           .maybeSingle();
 
-        const profileId = userRow?.auth_user_id || crypto.randomUUID();
+        const profileId = userRow?.auth_user_id || requestedId || randomUUID();
         upsertData = { id: profileId, email, ...updates };
       }
     }

--- a/dashboard.js
+++ b/dashboard.js
@@ -331,6 +331,7 @@ function buildSystemState(overrideProfile = null, overrideSession = null) {
     summaryProfile.compliance_mode,
     province
   ));
+  const normalizedProvince = province || ((complianceMode === 'AB' || complianceMode === 'BC') ? complianceMode : '');
 
   const canonicalProfile = {
     ...summaryProfile,
@@ -370,7 +371,7 @@ function buildSystemState(overrideProfile = null, overrideSession = null) {
       storedProfile.city,
       summaryProfile.city
     ),
-    province,
+    province: normalizedProvince,
     phone: firstNonEmpty(
       profile.phone,
       formProfile.phone,
@@ -587,6 +588,15 @@ async function parseApiJson(response) {
   } catch (error) {
     const preview = cleanText(rawText).slice(0, 180);
     throw new Error(preview || `Non-JSON API response (${response.status})`);
+  }
+}
+
+async function parseJsonWithDebug(response) {
+  const rawText = await response.text();
+  try {
+    return { ok: true, data: JSON.parse(rawText || '{}'), rawText };
+  } catch {
+    return { ok: false, data: null, rawText };
   }
 }
 
@@ -970,18 +980,20 @@ if (copyAffiliatePostBtn) {
           })
         });
 
-        const rawText = await response.text();
+        const parsed = await parseJsonWithDebug(response);
+        const requestId = response.headers.get("x-request-id") || "";
+        const responseMeta = `status=${response.status}${requestId ? ` req=${requestId}` : ""}`;
 
-        let data;
-        try {
-          data = JSON.parse(rawText);
-        } catch (parseError) {
-          console.error("[billing] Non-JSON response:", rawText);
-          throw new Error("Server error (non-JSON response)");
+        if (!parsed.ok) {
+          const preview = cleanText(parsed.rawText).slice(0, 200);
+          console.error("[billing] Non-JSON response:", parsed.rawText);
+          throw new Error(`Server error (non-JSON response, ${responseMeta})${preview ? `: ${preview}` : ""}`);
         }
 
+        const data = parsed.data || {};
+
         if (!response.ok) {
-          throw new Error(data.error || "Could not open billing portal.");
+          throw new Error(`${cleanText(data.error || "Could not open billing portal.")} (${responseMeta})`);
         }
 
         if (!data.url) {
@@ -2721,8 +2733,12 @@ async function loadAccountData(user, forceFresh = false) {
     setTextByIdForAll("referralCode", referral);
     setTextByIdForAll("referralCodeAffiliate", referral);
 
-    setTextByIdForAll("planNameBilling", currentNormalizedSession?.subscription?.plan || "Founder Beta");
-    setTextByIdForAll("subscriptionStatusBilling", currentNormalizedSession?.subscription?.status || "inactive");
+    const summaryPlan = cleanText(dashboardSummary?.plan_access?.plan_label || dashboardSummary?.account_snapshot?.plan || "");
+    const summaryStatus = cleanText(dashboardSummary?.account_snapshot?.status || "");
+    const effectivePlanLabel = cleanText(currentNormalizedSession?.subscription?.plan || summaryPlan || "Founder Beta");
+    const effectiveStatusLabel = cleanText(currentNormalizedSession?.subscription?.status || summaryStatus || "inactive");
+    setTextByIdForAll("planNameBilling", effectivePlanLabel);
+    setTextByIdForAll("subscriptionStatusBilling", effectiveStatusLabel);
     setTextByIdForAll("affiliateDirectCommission", "20% recurring");
     setTextByIdForAll("affiliateTierOverride", "5% second level");
     setTextByIdForAll("affiliatePartnerType", "Founding Partner");

--- a/docs/testing-fix-roadmap.md
+++ b/docs/testing-fix-roadmap.md
@@ -1,0 +1,70 @@
+# Dashboard Reliability Roadmap (10 Phases)
+
+## Constraints
+- Keep the API surface at **12 endpoints max**; prefer extending existing responses over adding endpoints.
+- Prioritize the current blocker: **profile info not syncing from Supabase into the client dashboard**.
+
+## Phase 1 — Stabilize summary payloads (immediate)
+- Fix server-side runtime breakers in `/api/get-dashboard-summary` so the dashboard always receives a valid payload.
+- Add source-count safeguards so merged listing stats never reference undefined variables.
+- Outcome: dashboard boot path no longer silently falls back due to 500s.
+
+## Phase 2 — Establish profile source of truth
+- Make `profiles` table the canonical write/read layer for dashboard profile fields.
+- Ensure `/api/profile` GET and POST return a consistent shape (`{ profile }` and `updated_at`).
+- Remove field drift between `account_snapshot`, `profile_snapshot`, and localStorage fallback.
+
+## Phase 3 — Identity hardening for sync correctness
+- Enforce user resolution precedence as: verified auth UID -> users.id -> normalized email fallback.
+- Audit all profile/account endpoints to ensure same identity strategy (no mixed casing or alternate email aliases).
+- Add debug markers to responses (`identity_source`, `matched_by`) for faster triage.
+
+## Phase 4 — Client hydration determinism
+- Refactor dashboard boot sequence to hydrate profile in one deterministic pass:
+  1. session,
+  2. account/session summary,
+  3. profile,
+  4. render.
+- Prevent stale local snapshot from overriding fresh Supabase profile unless API fails.
+- Add explicit "remote vs local" status message in setup panel.
+
+## Phase 5 — Write-path verification and optimistic UI
+- After profile save, re-read server profile and diff returned fields against form values.
+- Surface field-level sync errors (e.g., invalid URL normalization, missing write permissions).
+- Keep optimistic UI but rollback individual fields when server rejects updates.
+
+## Phase 6 — Database and RLS validation
+- Verify Supabase RLS allows authenticated users to read/write their own profile row by `id` and intended email fallback logic.
+- Confirm indexes for `profiles.id`, `profiles.email`, `subscriptions.user_id`, `posting_usage(user_id,date_key)`.
+- Add migration notes for required nullable/non-null profile fields.
+
+## Phase 7 — Observability and diagnostics
+- Add structured logs for dashboard-critical endpoints (`profile`, `extension-state`, `get-dashboard-summary`) with request IDs.
+- Add lightweight sync diagnostics in UI (last profile sync timestamp + source endpoint).
+- Create a reproducible "profile sync smoke test" script for local and production checks.
+
+## Phase 8 — API budget and consolidation (12 max)
+- Keep current 12 APIs; do not add net-new endpoints.
+- Consolidate overlapping data inside existing endpoints:
+  - `/api/get-dashboard-summary` as main read aggregator,
+  - `/api/profile` as profile write/read,
+  - `/api/extension-state` for extension compatibility only.
+- De-duplicate repeated subscription/profile fetch logic in shared helpers.
+
+## Phase 9 — Automated test coverage
+- Add integration tests for:
+  - profile save -> reload -> dashboard render roundtrip,
+  - UID-based identity and email fallback behavior,
+  - no-regression for account snapshot/profile snapshot hydration.
+- Add contract tests asserting required response keys used by `dashboard.js`.
+
+## Phase 10 — Performance + rollout safety
+- Introduce staged rollout flags for sync-path changes.
+- Add cache-busting controls only where needed (`_ts`) and avoid over-fetching on routine navigation.
+- Define rollback playbook and owner checklist for production incident handling.
+
+## Immediate next execution order
+1. Phase 1 + Phase 4 smoke validation.
+2. Phase 2 + Phase 3 identity/profile normalization.
+3. Phase 5 + Phase 7 visibility improvements.
+4. Phase 9 tests before broader refactors in Phase 8/10.

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables.');
+}
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false
+  }
+});


### PR DESCRIPTION
### Motivation
- Improve observability and error triage by attaching request IDs to billing portal requests and surfacing them to the client. 
- Harden identity resolution and profile upsert logic so profile reads/writes are deterministic when auth UID is absent. 
- Provide a temporary access override for testing and ensure dashboard summary payloads never reference undefined listing sources. 

### Description
- Add `randomUUID` usage and set the `x-request-id` header in `/api/create-billing-portal-session`, and include `request_id` in JSON responses and error payloads. 
- Improve client-side billing flow parsing with `parseJsonWithDebug`, surface the server `x-request-id` in errors, and make billing UI show effective plan/status from summary when session-level state is missing. 
- Extend `/api/profile` to accept an explicit `id`/`user_id` param for GET and to prefer a provided `requestedId` when creating a new profile row, falling back to `randomUUID()` if needed. 
- Add `lib/supabase.js` to centralize Supabase client creation using the service role key. 
- Add `ACCESS_OVERRIDE_EMAILS` to `/api/extension-state` with `clean`/`normalizeEmail` helpers and a `forcedAccess` mode that forces `isActive`, plan/status and raises `dailyLimit` to 25 for whitelisted emails. 
- In `/api/get-dashboard-summary` apply `hasTestingLimitOverride` to force `planValue` and `dailyLimit` when testing override is present, and compute `listingSourceCounts` to safely populate lifecycle/source counts instead of referencing possibly-undefined variables. 
- Adjust dashboard client (`dashboard.js`) to normalize province selection, use computed `effectivePlanLabel`/`effectiveStatusLabel` for billing displays, and use the improved JSON parsing/error messaging when opening the billing portal. 
- Add a new `docs/testing-fix-roadmap.md` describing a 10-phase plan for dashboard/profile reliability improvements. 

### Testing
- No new automated tests were added in this change. 
- Existing project checks were run locally: `npm run lint` and the existing test suite (`npm test`), and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc92600a5083259683ea3ad9bd7de9)