### PR TITLE
Add request IDs, diagnostics, forced-access override, and dashboard robustness improvements

### DIFF
--- a/api/create-billing-portal-session.js
+++ b/api/create-billing-portal-session.js
@@ -1,5 +1,6 @@
 import Stripe from "stripe";
 import { createClient } from "@supabase/supabase-js";
+import { randomUUID } from "node:crypto";
 import { requireVerifiedDashboardUser, getTrustedIdentity } from "./_shared/auth.js";
 
 function getStripeClient() {
@@ -342,8 +343,11 @@ async function customerHasManageableSubscription(stripeClient, customerId, mirro
 }
 
 export default async function handler(req, res) {
+  const requestId = randomUUID();
+  res.setHeader("x-request-id", requestId);
+
   if (req.method !== "POST") {
-    return json(res, 405, { error: "Method not allowed" });
+    return json(res, 405, { error: "Method not allowed", request_id: requestId });
   }
 
   try {
@@ -351,7 +355,7 @@ export default async function handler(req, res) {
 
     const body = parseBody(req);
     if (body.__parse_error) {
-      return json(res, 400, { error: body.__parse_error });
+      return json(res, 400, { error: body.__parse_error, request_id: requestId });
     }
 
     const verifiedUser = await requireVerifiedDashboardUser(req, res);
@@ -378,7 +382,8 @@ export default async function handler(req, res) {
       return json(res, 200, {
         redirectToCheckout: true,
         message: "Billing profile not active yet. Start checkout first.",
-        checkoutContext
+        checkoutContext,
+        request_id: requestId
       });
     }
 
@@ -393,7 +398,8 @@ export default async function handler(req, res) {
       return json(res, 200, {
         redirectToCheckout: true,
         message: "Stripe customer found, but no active plan is attached yet. Start checkout to activate billing.",
-        checkoutContext
+        checkoutContext,
+        request_id: requestId
       });
     }
 
@@ -403,13 +409,15 @@ export default async function handler(req, res) {
     });
 
     return json(res, 200, {
-      url: session.url
+      url: session.url,
+      request_id: requestId
     });
   } catch (error) {
     console.error("[billing-portal] fatal error:", error);
 
     return json(res, 500, {
-      error: error?.message || "Failed to create billing portal session"
+      error: error?.message || "Failed to create billing portal session",
+      request_id: requestId
     });
   }
 }

--- a/api/extension-state.js
+++ b/api/extension-state.js
@@ -1,5 +1,15 @@
 import { supabase } from '../lib/supabase.js';
 
+const ACCESS_OVERRIDE_EMAILS = new Set(['damian044@icloud.com']);
+
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function normalizeEmail(value) {
+  return clean(value).toLowerCase();
+}
+
 const CORS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, OPTIONS',
@@ -19,7 +29,7 @@ export default async function handler(req, res) {
 
   // Accept Bearer token or ?email= param
   let authUid = null;
-  let email = req.query.email?.toLowerCase();
+  let email = normalizeEmail(req.query.email);
 
   const authHeader = req.headers.authorization || '';
   if (authHeader.startsWith('Bearer ')) {
@@ -27,7 +37,7 @@ export default async function handler(req, res) {
     const { data: { user }, error } = await supabase.auth.getUser(token);
     if (!error && user) {
       authUid = user.id;
-      email = user.email?.toLowerCase();
+      email = normalizeEmail(user.email);
     }
   }
 
@@ -66,14 +76,16 @@ export default async function handler(req, res) {
     const { data: usage } = await usageQuery.maybeSingle();
 
     // 4. Determine access
+    const forcedAccess = ACCESS_OVERRIDE_EMAILS.has(normalizeEmail(email));
     const isActive =
+      forcedAccess ||
       subscription?.is_active ||
       subscription?.access_active ||
       subscription?.bridge_access ||
       subscription?.subscription_status === 'active' ||
       subscription?.subscription_status === 'trialing';
 
-    const dailyLimit = subscription?.daily_posting_limit || 5;
+    const dailyLimit = forcedAccess ? 25 : (subscription?.daily_posting_limit || 5);
     const postsToday = usage?.posts_today || 0;
     const canPost = isActive && postsToday < dailyLimit;
 
@@ -81,8 +93,8 @@ export default async function handler(req, res) {
       success: true,
       profile: profile || null,
       subscription: {
-        status: subscription?.subscription_status || 'none',
-        plan: subscription?.plan_type || 'Beta',
+        status: forcedAccess ? 'active' : (subscription?.subscription_status || 'none'),
+        plan: forcedAccess ? 'Pro' : (subscription?.plan_type || 'Beta'),
         isActive,
         dailyLimit,
         postsToday,

--- a/api/get-dashboard-summary.js
+++ b/api/get-dashboard-summary.js
@@ -949,8 +949,10 @@ export default async function handler(req, res) {
     ]);
     const computed = buildComputedSummary(rows);
     const snapshot = subscriptionRow?.account_snapshot && typeof subscriptionRow.account_snapshot === 'object' ? subscriptionRow.account_snapshot : {};
-    const planValue = clean(subscriptionRow?.plan_type || subscriptionRow?.plan_name || subscriptionRow?.plan || user?.plan || user?.user_type || 'Founder Beta');
     const forcedAccess = hasTestingLimitOverride(finalEmail);
+    const planValue = forcedAccess
+      ? 'Pro'
+      : clean(subscriptionRow?.plan_type || subscriptionRow?.plan_name || subscriptionRow?.plan || user?.plan || user?.user_type || 'Founder Beta');
     const configuredLimit = safeNumber(snapshot.posting_limit ?? subscriptionRow?.daily_posting_limit ?? subscriptionRow?.posting_limit ?? inferPostingLimitFromPlan(planValue), inferPostingLimitFromPlan(planValue));
     const dailyLimit = forcedAccess ? 25 : configuredLimit;
     const usageToday = Math.max(safeNumber(postingUsageRow?.posts_today ?? postingUsageRow?.posts_used ?? postingUsageRow?.used_today, 0), safeNumber(snapshot.posts_today ?? snapshot.posts_used_today, 0), safeNumber(computed.posts_today, 0));
@@ -1068,6 +1070,14 @@ export default async function handler(req, res) {
       totalMessages: computed.total_messages
     });
 
+    const listingSourceCounts = rows.reduce((acc, row) => {
+      const source = clean(row?.source_table || '');
+      if (source === 'user_listings') acc.user_listings += 1;
+      else if (source === 'listings') acc.listings += 1;
+      else acc.other += 1;
+      return acc;
+    }, { user_listings: 0, listings: 0, other: 0 });
+
     const recentListings = rows.slice(0, 12).map((row) => ({
       id: row.id,
       title: row.title,
@@ -1168,9 +1178,10 @@ export default async function handler(req, res) {
           needs_action_count: computed.needs_action_count,
           lifecycle_updated_at: clean(snapshot.lifecycle_updated_at || ''),
           source_counts: {
-            user_listings: userListingRows.length,
-            listings: legacyListingRows.length,
-            merged: rows.length
+            user_listings: listingSourceCounts.user_listings,
+            listings: listingSourceCounts.listings,
+            merged: rows.length,
+            other: listingSourceCounts.other
           }
         },
         recent_activity: recentListings.slice(0, 8).map((row) => ({
@@ -1189,9 +1200,10 @@ export default async function handler(req, res) {
           snapshot_active_listings: safeNumber(snapshot.active_listings ?? computed.active_listings, 0),
           lifecycle_updated_at: clean(snapshot.lifecycle_updated_at || ''),
           sources: {
-            user_listings: userListingRows.length,
-            listings: legacyListingRows.length,
-            merged: rows.length
+            user_listings: listingSourceCounts.user_listings,
+            listings: listingSourceCounts.listings,
+            merged: rows.length,
+            other: listingSourceCounts.other
           }
         },
         account_snapshot: {

--- a/api/profile.js
+++ b/api/profile.js
@@ -1,4 +1,5 @@
 import { supabase } from '../lib/supabase.js';
+import { randomUUID } from 'node:crypto';
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
@@ -30,6 +31,7 @@ export default async function handler(req, res) {
   }
 
   // Fallback: email from query or body
+  const requestedId = req.query.id || req.body?.id || req.body?.user_id || null;
   if (!email) {
     email = req.query.email || req.body?.email;
   }
@@ -49,6 +51,8 @@ export default async function handler(req, res) {
 
     if (authUid) {
       query = query.eq('id', authUid);
+    } else if (requestedId) {
+      query = query.eq('id', requestedId);
     } else {
       query = query.ilike('email', email);
     }
@@ -115,7 +119,7 @@ export default async function handler(req, res) {
           .ilike('email', email)
           .maybeSingle();
 
-        const profileId = userRow?.auth_user_id || crypto.randomUUID();
+        const profileId = userRow?.auth_user_id || requestedId || randomUUID();
         upsertData = { id: profileId, email, ...updates };
       }
     }

--- a/dashboard.js
+++ b/dashboard.js
@@ -331,6 +331,7 @@ function buildSystemState(overrideProfile = null, overrideSession = null) {
     summaryProfile.compliance_mode,
     province
   ));
+  const normalizedProvince = province || ((complianceMode === 'AB' || complianceMode === 'BC') ? complianceMode : '');
 
   const canonicalProfile = {
     ...summaryProfile,
@@ -370,7 +371,7 @@ function buildSystemState(overrideProfile = null, overrideSession = null) {
       storedProfile.city,
       summaryProfile.city
     ),
-    province,
+    province: normalizedProvince,
     phone: firstNonEmpty(
       profile.phone,
       formProfile.phone,
@@ -590,6 +591,15 @@ async function parseApiJson(response) {
   }
 }
 
+async function parseJsonWithDebug(response) {
+  const rawText = await response.text();
+  try {
+    return { ok: true, data: JSON.parse(rawText || '{}'), rawText };
+  } catch {
+    return { ok: false, data: null, rawText };
+  }
+}
+
 function openReadCopyModal({ title = "Read in Dashboard", subtitle = "Read this in the dashboard first, then copy only if needed.", eyebrow = "Dashboard Script", body = "" } = {}) {
   const modal = document.getElementById("readCopyModal");
   if (!modal) return;
@@ -655,6 +665,7 @@ function bindCreditActionButtons() {
 let dashboardListings = [];
 let filteredListings = [];
 let dashboardListingsMeta = { total: 0, source_counts: { user_listings: 0, listings: 0, merged: 0 }, used_summary_fallback: false, source: "api" };
+let dashboardListingsDiagnostics = { raw_rows: 0, normalized_rows: 0, dropped_rows: 0 };
 let listingQuickFilter = "all";
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -970,18 +981,20 @@ if (copyAffiliatePostBtn) {
           })
         });
 
-        const rawText = await response.text();
+        const parsed = await parseJsonWithDebug(response);
+        const requestId = response.headers.get("x-request-id") || "";
+        const responseMeta = `status=${response.status}${requestId ? ` req=${requestId}` : ""}`;
 
-        let data;
-        try {
-          data = JSON.parse(rawText);
-        } catch (parseError) {
-          console.error("[billing] Non-JSON response:", rawText);
-          throw new Error("Server error (non-JSON response)");
+        if (!parsed.ok) {
+          const preview = cleanText(parsed.rawText).slice(0, 200);
+          console.error("[billing] Non-JSON response:", parsed.rawText);
+          throw new Error(`Server error (non-JSON response, ${responseMeta})${preview ? `: ${preview}` : ""}`);
         }
 
+        const data = parsed.data || {};
+
         if (!response.ok) {
-          throw new Error(data.error || "Could not open billing portal.");
+          throw new Error(`${cleanText(data.error || "Could not open billing portal.")} (${responseMeta})`);
         }
 
         if (!data.url) {
@@ -1041,6 +1054,18 @@ if (copyAffiliatePostBtn) {
     });
   }
 
+  document.querySelectorAll("[data-filter]").forEach((button) => {
+    if (button.dataset.boundListingFilter === "true") return;
+    button.dataset.boundListingFilter = "true";
+    button.addEventListener("click", () => {
+      listingQuickFilter = clean(button.getAttribute("data-filter") || "all").toLowerCase() || "all";
+      document.querySelectorAll("[data-filter]").forEach((other) => {
+        other.classList.toggle("active", other === button);
+      });
+      applyListingFiltersAndRender();
+    });
+  });
+
   window.addEventListener("resize", debounce(() => {
     drawActivityChart(buildChartSeries());
   }, 150));
@@ -1072,11 +1097,16 @@ async function refreshDashboardState(forceFresh = false) {
 async function loadListingDashboardData(forceFresh = false) {
   try {
     dashboardSummary = await fetchDashboardSummary(forceFresh);
-    dashboardListings = await fetchUserListings(forceFresh);
+    const rawListings = await fetchUserListings(forceFresh);
 
-    dashboardListings = Array.isArray(dashboardListings)
-      ? dashboardListings.map(normalizeListingRecord).filter(Boolean)
+    dashboardListings = Array.isArray(rawListings)
+      ? rawListings.map(normalizeListingRecord).filter(Boolean)
       : [];
+    dashboardListingsDiagnostics = {
+      raw_rows: Array.isArray(rawListings) ? rawListings.length : 0,
+      normalized_rows: dashboardListings.length,
+      dropped_rows: Math.max((Array.isArray(rawListings) ? rawListings.length : 0) - dashboardListings.length, 0)
+    };
 
     if (!dashboardSummary) {
       dashboardSummary = buildDashboardSummaryFromListings(dashboardListings);
@@ -1094,6 +1124,7 @@ async function loadListingDashboardData(forceFresh = false) {
   } catch (error) {
     console.error("loadListingDashboardData error:", error);
     dashboardListings = [];
+    dashboardListingsDiagnostics = { raw_rows: 0, normalized_rows: 0, dropped_rows: 0 };
     dashboardSummary = buildDashboardSummaryFromListings(dashboardListings);
     filteredListings = [];
     setSystemStateFromSources(currentProfile, currentNormalizedSession);
@@ -1395,6 +1426,40 @@ function mergeSummaryWithListings(summary, listings) {
     sessionPostsToday,
     snapshotPostsToday
   );
+  const planFromSession = cleanText(currentNormalizedSession?.subscription?.plan || "");
+  const planFromPlanAccess = cleanText(summary?.plan_access?.plan_label || "");
+  const planFromSnapshot = cleanText(summary?.account_snapshot?.plan || "");
+  const statusFromSession = cleanText(currentNormalizedSession?.subscription?.status || "");
+  const statusFromSnapshot = cleanText(summary?.account_snapshot?.status || "");
+  const limitFromSession = numberOrZero(currentNormalizedSession?.subscription?.posting_limit);
+  const limitFromPlanAccess = numberOrZero(summary?.plan_access?.posting_limit);
+  const limitFromSnapshot = numberOrZero(summary?.account_snapshot?.posting_limit);
+  const remainingFromSession = numberOrZero(currentNormalizedSession?.subscription?.posts_remaining);
+  const remainingFromSnapshot = numberOrZero(summary?.account_snapshot?.posts_remaining);
+  const setupFromSummary = summary?.setup_status && Object.keys(summary.setup_status || {}).length > 0;
+
+  const canonicalAccess = {
+    plan: planFromSession || planFromPlanAccess || planFromSnapshot || "Founder Beta",
+    status: statusFromSession || statusFromSnapshot || "inactive",
+    posting_limit: limitFromSession || limitFromPlanAccess || limitFromSnapshot || 0,
+    posts_remaining: remainingFromSession || remainingFromSnapshot || 0
+  };
+
+  const stateProvenance = {
+    posts_today: bestPostsToday === snapshotPostsToday && snapshotPostsToday > 0
+      ? "summary.account_snapshot.posts_today"
+      : (bestPostsToday === sessionPostsToday && sessionPostsToday > 0
+        ? "session.subscription.posts_today"
+        : "computed.listings.posts_today"),
+    plan: planFromSession
+      ? "session.subscription.plan"
+      : (planFromPlanAccess ? "summary.plan_access.plan_label" : (planFromSnapshot ? "summary.account_snapshot.plan" : "default")),
+    status: statusFromSession ? "session.subscription.status" : (statusFromSnapshot ? "summary.account_snapshot.status" : "default"),
+    posting_limit: limitFromSession > 0
+      ? "session.subscription.posting_limit"
+      : (limitFromPlanAccess > 0 ? "summary.plan_access.posting_limit" : (limitFromSnapshot > 0 ? "summary.account_snapshot.posting_limit" : "default")),
+    setup_status: setupFromSummary ? "summary.setup_status" : "fallback"
+  };
 
   return {
     posts_today: bestPostsToday,
@@ -1414,6 +1479,8 @@ function mergeSummaryWithListings(summary, listings) {
     top_listing_title: clean(summary.top_listing_title || computed.top_listing_title || "None yet"),
     account_snapshot: summary.account_snapshot || {},
     setup_status: summary.setup_status || {},
+    canonical_access: canonicalAccess,
+    state_provenance: stateProvenance,
     manager_access: Boolean(summary.manager_access),
     action_center: summary.action_center || summary.daily_ops_queues || {},
     daily_ops_queues: summary.daily_ops_queues || summary.action_center || {},
@@ -1543,6 +1610,7 @@ function renderDashboardAnalytics() {
   setTextByIdForAll("kpiMessages", String(numberOrZero(dashboardSummary?.total_messages)));
   setTextByIdForAll("kpiPostsRemaining", String(numberOrZero(currentNormalizedSession?.subscription?.posts_remaining ?? dashboardSummary?.account_snapshot?.posts_remaining)));
   setTextByIdForAll("kpiDailyLimit", String(numberOrZero(currentNormalizedSession?.subscription?.posting_limit ?? dashboardSummary?.account_snapshot?.posting_limit)));
+  renderRevenueActionPanels();
 
   // lifecycle-ready safe no-op if ids do not exist yet
   setTextByIdForAll("kpiReviewQueue", String(numberOrZero(dashboardSummary?.review_queue_count)));
@@ -1567,6 +1635,43 @@ function renderDashboardAnalytics() {
   renderComplianceWorkspace();
   renderToolsWorkspace();
   drawActivityChart(buildChartSeries());
+}
+
+function updateListingFilterCounts() {
+  const rows = Array.isArray(dashboardListings) ? dashboardListings : [];
+  const countBy = (predicate) => rows.filter(predicate).length;
+  const counts = {
+    all: rows.length,
+    review: countBy((item) => {
+      const lifecycle = clean((item.lifecycle_status || "").toLowerCase());
+      const bucket = clean((item.review_bucket || "").toLowerCase()).replace(/[\s_-]+/g, "");
+      return ["review_delete", "review_price_update", "review_new"].includes(lifecycle) || ["removedvehicles", "pricechanges", "newvehicles"].includes(bucket);
+    }),
+    stale: countBy((item) => {
+      const lifecycle = clean((item.lifecycle_status || "").toLowerCase());
+      const bucket = clean((item.review_bucket || "").toLowerCase()).replace(/[\s_-]+/g, "");
+      const status = clean((item.status || "").toLowerCase());
+      return lifecycle === "stale" || status === "stale" || lifecycle === "review_delete" || bucket === "removedvehicles";
+    }),
+    price: countBy((item) => clean((item.lifecycle_status || "").toLowerCase()) === "review_price_update" || clean((item.review_bucket || "").toLowerCase()).replace(/[\s_-]+/g, "") === "pricechanges"),
+    new: countBy((item) => clean((item.lifecycle_status || "").toLowerCase()) === "review_new" || clean((item.review_bucket || "").toLowerCase()).replace(/[\s_-]+/g, "") === "newvehicles"),
+    weak: countBy((item) => Boolean(item.weak)),
+    needs_action: countBy((item) => Boolean(item.needs_action)),
+    promote: countBy((item) => Boolean(item.promote_now)),
+    likely_sold: countBy((item) => Boolean(item.likely_sold)),
+    active: countBy((item) => {
+      const status = clean((item.status || "").toLowerCase());
+      const lifecycle = clean((item.lifecycle_status || "").toLowerCase());
+      return !["sold", "deleted", "inactive", "stale"].includes(status) && lifecycle !== "review_delete";
+    })
+  };
+
+  document.querySelectorAll("[data-filter]").forEach((button) => {
+    const key = clean(button.getAttribute("data-filter") || "all").toLowerCase();
+    const base = clean(button.textContent || "");
+    const label = base.replace(/\s*\(\d+\)\s*$/, "");
+    button.textContent = `${label} (${numberOrZero(counts[key])})`;
+  });
 }
 
 
@@ -1940,6 +2045,7 @@ function renderAnalyticsHub() {
 }
 
 function applyListingFiltersAndRender() {
+  updateListingFilterCounts();
   const searchTerm = clean((document.getElementById("listingSearchInput")?.value || "").toLowerCase());
   const sortMode = clean(document.getElementById("listingSortSelect")?.value || "popular");
 
@@ -2054,6 +2160,7 @@ function renderListingDataState(listings = []) {
     statusEl.textContent = [
       `${mergedCount} listing${mergedCount === 1 ? "" : "s"} loaded.`,
       `Rows: user_listings ${numberOrZero(counts.user_listings)} • listings ${numberOrZero(counts.listings)} • merged ${numberOrZero(counts.merged || mergedCount)}.`,
+      `Normalize: raw ${numberOrZero(dashboardListingsDiagnostics.raw_rows)} • rendered ${numberOrZero(dashboardListingsDiagnostics.normalized_rows)} • dropped ${numberOrZero(dashboardListingsDiagnostics.dropped_rows)}.`,
       summary.lifecycle_updated_at ? `Last lifecycle sync: ${cleanText(summary.lifecycle_updated_at)}.` : ""
     ].filter(Boolean).join(" ");
   }
@@ -2721,8 +2828,12 @@ async function loadAccountData(user, forceFresh = false) {
     setTextByIdForAll("referralCode", referral);
     setTextByIdForAll("referralCodeAffiliate", referral);
 
-    setTextByIdForAll("planNameBilling", currentNormalizedSession?.subscription?.plan || "Founder Beta");
-    setTextByIdForAll("subscriptionStatusBilling", currentNormalizedSession?.subscription?.status || "inactive");
+    const summaryPlan = cleanText(dashboardSummary?.plan_access?.plan_label || dashboardSummary?.account_snapshot?.plan || "");
+    const summaryStatus = cleanText(dashboardSummary?.account_snapshot?.status || "");
+    const effectivePlanLabel = cleanText(currentNormalizedSession?.subscription?.plan || summaryPlan || "Founder Beta");
+    const effectiveStatusLabel = cleanText(currentNormalizedSession?.subscription?.status || summaryStatus || "inactive");
+    setTextByIdForAll("planNameBilling", effectivePlanLabel);
+    setTextByIdForAll("subscriptionStatusBilling", effectiveStatusLabel);
     setTextByIdForAll("affiliateDirectCommission", "20% recurring");
     setTextByIdForAll("affiliateTierOverride", "5% second level");
     setTextByIdForAll("affiliatePartnerType", "Founding Partner");
@@ -3018,11 +3129,13 @@ function persistProfileSnapshots(profileSnapshot, session) {
 function renderSetupSnapshot() {
   const snapshot = dashboardSummary?.account_snapshot || {};
   const setup = dashboardSummary?.setup_status || {};
+  const canonicalAccess = dashboardSummary?.canonical_access || {};
+  const provenance = dashboardSummary?.state_provenance || {};
   const canonicalProfile = getCanonicalProfileState();
   const subscription = getCanonicalSubscriptionState();
 
-  setTextByIdForAll("snapshotPostingLimit", String(Math.max(numberOrZero(snapshot.posting_limit), numberOrZero(subscription.posting_limit))));
-  setTextByIdForAll("snapshotPostsRemaining", String(Math.max(numberOrZero(snapshot.posts_remaining), numberOrZero(currentNormalizedSession?.subscription?.posts_remaining))));
+  setTextByIdForAll("snapshotPostingLimit", String(Math.max(numberOrZero(canonicalAccess.posting_limit), numberOrZero(snapshot.posting_limit), numberOrZero(subscription.posting_limit))));
+  setTextByIdForAll("snapshotPostsRemaining", String(Math.max(numberOrZero(canonicalAccess.posts_remaining), numberOrZero(snapshot.posts_remaining), numberOrZero(currentNormalizedSession?.subscription?.posts_remaining))));
   setTextByIdForAll("snapshotPostsUsed", String(Math.max(numberOrZero(snapshot.posts_today ?? snapshot.posts_used_today), numberOrZero(currentNormalizedSession?.subscription?.posts_today), numberOrZero(dashboardSummary?.posts_today))));
   setTextByIdForAll("snapshotBillingSource", clean(currentNormalizedSession?.subscription?.billing_source || snapshot.billing_source || "subscriptions/users") || "subscriptions/users");
   setTextByIdForAll("snapshotCurrentPeriodEnd", formatShortDate(snapshot.current_period_end || currentNormalizedSession?.subscription?.current_period_end || ""));
@@ -3044,7 +3157,15 @@ function renderSetupSnapshot() {
         setup.compliance_mode_present ? null : "compliance mode missing"
       ].filter(Boolean);
 
-  setStatus("snapshotSetupSummary", summaryBits.length ? `Setup gaps: ${summaryBits.join(" • ")}` : "Account setup looks complete for beta use.");
+  const sourceBits = [
+    provenance.plan ? `plan=${provenance.plan}` : "",
+    provenance.posting_limit ? `limit=${provenance.posting_limit}` : "",
+    provenance.setup_status ? `setup=${provenance.setup_status}` : ""
+  ].filter(Boolean);
+  setStatus(
+    "snapshotSetupSummary",
+    `${summaryBits.length ? `Setup gaps: ${summaryBits.join(" • ")}` : "Account setup looks complete for beta use."}${sourceBits.length ? ` (sources: ${sourceBits.join(" | ")})` : ""}`
+  );
 }
 
 function renderAccessState(session) {

--- a/docs/testing-fix-roadmap.md
+++ b/docs/testing-fix-roadmap.md
@@ -1,0 +1,70 @@
+# Dashboard Reliability Roadmap (10 Phases)
+
+## Constraints
+- Keep the API surface at **12 endpoints max**; prefer extending existing responses over adding endpoints.
+- Prioritize the current blocker: **profile info not syncing from Supabase into the client dashboard**.
+
+## Phase 1 — Stabilize summary payloads (immediate)
+- Fix server-side runtime breakers in `/api/get-dashboard-summary` so the dashboard always receives a valid payload.
+- Add source-count safeguards so merged listing stats never reference undefined variables.
+- Outcome: dashboard boot path no longer silently falls back due to 500s.
+
+## Phase 2 — Establish profile source of truth
+- Make `profiles` table the canonical write/read layer for dashboard profile fields.
+- Ensure `/api/profile` GET and POST return a consistent shape (`{ profile }` and `updated_at`).
+- Remove field drift between `account_snapshot`, `profile_snapshot`, and localStorage fallback.
+
+## Phase 3 — Identity hardening for sync correctness
+- Enforce user resolution precedence as: verified auth UID -> users.id -> normalized email fallback.
+- Audit all profile/account endpoints to ensure same identity strategy (no mixed casing or alternate email aliases).
+- Add debug markers to responses (`identity_source`, `matched_by`) for faster triage.
+
+## Phase 4 — Client hydration determinism
+- Refactor dashboard boot sequence to hydrate profile in one deterministic pass:
+  1. session,
+  2. account/session summary,
+  3. profile,
+  4. render.
+- Prevent stale local snapshot from overriding fresh Supabase profile unless API fails.
+- Add explicit "remote vs local" status message in setup panel.
+
+## Phase 5 — Write-path verification and optimistic UI
+- After profile save, re-read server profile and diff returned fields against form values.
+- Surface field-level sync errors (e.g., invalid URL normalization, missing write permissions).
+- Keep optimistic UI but rollback individual fields when server rejects updates.
+
+## Phase 6 — Database and RLS validation
+- Verify Supabase RLS allows authenticated users to read/write their own profile row by `id` and intended email fallback logic.
+- Confirm indexes for `profiles.id`, `profiles.email`, `subscriptions.user_id`, `posting_usage(user_id,date_key)`.
+- Add migration notes for required nullable/non-null profile fields.
+
+## Phase 7 — Observability and diagnostics
+- Add structured logs for dashboard-critical endpoints (`profile`, `extension-state`, `get-dashboard-summary`) with request IDs.
+- Add lightweight sync diagnostics in UI (last profile sync timestamp + source endpoint).
+- Create a reproducible "profile sync smoke test" script for local and production checks.
+
+## Phase 8 — API budget and consolidation (12 max)
+- Keep current 12 APIs; do not add net-new endpoints.
+- Consolidate overlapping data inside existing endpoints:
+  - `/api/get-dashboard-summary` as main read aggregator,
+  - `/api/profile` as profile write/read,
+  - `/api/extension-state` for extension compatibility only.
+- De-duplicate repeated subscription/profile fetch logic in shared helpers.
+
+## Phase 9 — Automated test coverage
+- Add integration tests for:
+  - profile save -> reload -> dashboard render roundtrip,
+  - UID-based identity and email fallback behavior,
+  - no-regression for account snapshot/profile snapshot hydration.
+- Add contract tests asserting required response keys used by `dashboard.js`.
+
+## Phase 10 — Performance + rollout safety
+- Introduce staged rollout flags for sync-path changes.
+- Add cache-busting controls only where needed (`_ts`) and avoid over-fetching on routine navigation.
+- Define rollback playbook and owner checklist for production incident handling.
+
+## Immediate next execution order
+1. Phase 1 + Phase 4 smoke validation.
+2. Phase 2 + Phase 3 identity/profile normalization.
+3. Phase 5 + Phase 7 visibility improvements.
+4. Phase 9 tests before broader refactors in Phase 8/10.

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables.');
+}
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false
+  }
+});


### PR DESCRIPTION
### Motivation

- Improve observability and error diagnostics for billing and dashboard APIs by surfacing request identifiers and richer debug payloads. 
- Make listing hydration and source-counts deterministic so the client can reliably render merged listing data. 
- Provide a temporary forced-access override for troubleshooting specific emails and raise their posting limits for testing. 
- Harden profile identity resolution on read/write to avoid lost-upserts when an auth UID is not present.

### Description

- Add request tracing to billing portal endpoint by generating a `request_id` header with `randomUUID()` and including `request_id` in JSON responses and error payloads in `api/create-billing-portal-session.js`. 
- Improve billing client handling in `dashboard.js` by adding `parseJsonWithDebug()`, including the request id in client-side error messages, and better non-JSON response logging. 
- Add forced-access testing override in `api/extension-state.js` with `ACCESS_OVERRIDE_EMAILS`, normalize email handling, mark forced accounts as active with an increased `dailyLimit`, and include `plan/status` overrides in the response. 
- Update `api/get-dashboard-summary.js` to respect testing overrides (`hasTestingLimitOverride`), compute `listingSourceCounts`, and include `canonical_access` and `state_provenance` to make plan/status/limit provenance explicit. 
- Add client-side listing diagnostics and filter improvements in `dashboard.js`, including `dashboardListingsDiagnostics`, UI filter binding, listing counts update (`updateListingFilterCounts()`), and improved rendering of source/count/debug info. 
- Harden `api/profile.js` identity resolution by accepting an explicit `id` parameter (`requestedId`) for reads and using `randomUUID()` or the provided `requestedId` as the profile UUID when creating profiles without an auth UID. 
- Add a lightweight Supabase client wrapper `lib/supabase.js` that instantiates a service-role client using `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`. 
- Add `docs/testing-fix-roadmap.md` documenting a 10-phase reliability roadmap for dashboard/profile sync and testing. 

### Testing

- No automated tests were added or executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc92600a5083259683ea3ad9bd7de9)