### PR TITLE
Improve identity resolution, diagnostics, and billing portal tracing; refactor listings & profile sync

### DIFF
--- a/api/create-billing-portal-session.js
+++ b/api/create-billing-portal-session.js
@@ -1,5 +1,6 @@
 import Stripe from "stripe";
 import { createClient } from "@supabase/supabase-js";
+import { randomUUID } from "node:crypto";
 import { requireVerifiedDashboardUser, getTrustedIdentity } from "./_shared/auth.js";
 
 function getStripeClient() {
@@ -342,8 +343,11 @@ async function customerHasManageableSubscription(stripeClient, customerId, mirro
 }
 
 export default async function handler(req, res) {
+  const requestId = randomUUID();
+  res.setHeader("x-request-id", requestId);
+
   if (req.method !== "POST") {
-    return json(res, 405, { error: "Method not allowed" });
+    return json(res, 405, { error: "Method not allowed", request_id: requestId });
   }
 
   try {
@@ -351,7 +355,7 @@ export default async function handler(req, res) {
 
     const body = parseBody(req);
     if (body.__parse_error) {
-      return json(res, 400, { error: body.__parse_error });
+      return json(res, 400, { error: body.__parse_error, request_id: requestId });
     }
 
     const verifiedUser = await requireVerifiedDashboardUser(req, res);
@@ -378,7 +382,8 @@ export default async function handler(req, res) {
       return json(res, 200, {
         redirectToCheckout: true,
         message: "Billing profile not active yet. Start checkout first.",
-        checkoutContext
+        checkoutContext,
+        request_id: requestId
       });
     }
 
@@ -393,7 +398,8 @@ export default async function handler(req, res) {
       return json(res, 200, {
         redirectToCheckout: true,
         message: "Stripe customer found, but no active plan is attached yet. Start checkout to activate billing.",
-        checkoutContext
+        checkoutContext,
+        request_id: requestId
       });
     }
 
@@ -403,13 +409,15 @@ export default async function handler(req, res) {
     });
 
     return json(res, 200, {
-      url: session.url
+      url: session.url,
+      request_id: requestId
     });
   } catch (error) {
     console.error("[billing-portal] fatal error:", error);
 
     return json(res, 500, {
-      error: error?.message || "Failed to create billing portal session"
+      error: error?.message || "Failed to create billing portal session",
+      request_id: requestId
     });
   }
 }

--- a/api/extension-state.js
+++ b/api/extension-state.js
@@ -1,5 +1,15 @@
 import { supabase } from '../lib/supabase.js';
 
+const ACCESS_OVERRIDE_EMAILS = new Set(['damian044@icloud.com']);
+
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function normalizeEmail(value) {
+  return clean(value).toLowerCase();
+}
+
 const CORS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, OPTIONS',
@@ -19,7 +29,7 @@ export default async function handler(req, res) {
 
   // Accept Bearer token or ?email= param
   let authUid = null;
-  let email = req.query.email?.toLowerCase();
+  let email = normalizeEmail(req.query.email);
 
   const authHeader = req.headers.authorization || '';
   if (authHeader.startsWith('Bearer ')) {
@@ -27,7 +37,7 @@ export default async function handler(req, res) {
     const { data: { user }, error } = await supabase.auth.getUser(token);
     if (!error && user) {
       authUid = user.id;
-      email = user.email?.toLowerCase();
+      email = normalizeEmail(user.email);
     }
   }
 
@@ -66,14 +76,16 @@ export default async function handler(req, res) {
     const { data: usage } = await usageQuery.maybeSingle();
 
     // 4. Determine access
+    const forcedAccess = ACCESS_OVERRIDE_EMAILS.has(normalizeEmail(email));
     const isActive =
+      forcedAccess ||
       subscription?.is_active ||
       subscription?.access_active ||
       subscription?.bridge_access ||
       subscription?.subscription_status === 'active' ||
       subscription?.subscription_status === 'trialing';
 
-    const dailyLimit = subscription?.daily_posting_limit || 5;
+    const dailyLimit = forcedAccess ? 25 : (subscription?.daily_posting_limit || 5);
     const postsToday = usage?.posts_today || 0;
     const canPost = isActive && postsToday < dailyLimit;
 
@@ -81,8 +93,8 @@ export default async function handler(req, res) {
       success: true,
       profile: profile || null,
       subscription: {
-        status: subscription?.subscription_status || 'none',
-        plan: subscription?.plan_type || 'Beta',
+        status: forcedAccess ? 'active' : (subscription?.subscription_status || 'none'),
+        plan: forcedAccess ? 'Pro' : (subscription?.plan_type || 'Beta'),
         isActive,
         dailyLimit,
         postsToday,

--- a/api/get-dashboard-summary.js
+++ b/api/get-dashboard-summary.js
@@ -949,8 +949,10 @@ export default async function handler(req, res) {
     ]);
     const computed = buildComputedSummary(rows);
     const snapshot = subscriptionRow?.account_snapshot && typeof subscriptionRow.account_snapshot === 'object' ? subscriptionRow.account_snapshot : {};
-    const planValue = clean(subscriptionRow?.plan_type || subscriptionRow?.plan_name || subscriptionRow?.plan || user?.plan || user?.user_type || 'Founder Beta');
     const forcedAccess = hasTestingLimitOverride(finalEmail);
+    const planValue = forcedAccess
+      ? 'Pro'
+      : clean(subscriptionRow?.plan_type || subscriptionRow?.plan_name || subscriptionRow?.plan || user?.plan || user?.user_type || 'Founder Beta');
     const configuredLimit = safeNumber(snapshot.posting_limit ?? subscriptionRow?.daily_posting_limit ?? subscriptionRow?.posting_limit ?? inferPostingLimitFromPlan(planValue), inferPostingLimitFromPlan(planValue));
     const dailyLimit = forcedAccess ? 25 : configuredLimit;
     const usageToday = Math.max(safeNumber(postingUsageRow?.posts_today ?? postingUsageRow?.posts_used ?? postingUsageRow?.used_today, 0), safeNumber(snapshot.posts_today ?? snapshot.posts_used_today, 0), safeNumber(computed.posts_today, 0));
@@ -1068,6 +1070,14 @@ export default async function handler(req, res) {
       totalMessages: computed.total_messages
     });
 
+    const listingSourceCounts = rows.reduce((acc, row) => {
+      const source = clean(row?.source_table || '');
+      if (source === 'user_listings') acc.user_listings += 1;
+      else if (source === 'listings') acc.listings += 1;
+      else acc.other += 1;
+      return acc;
+    }, { user_listings: 0, listings: 0, other: 0 });
+
     const recentListings = rows.slice(0, 12).map((row) => ({
       id: row.id,
       title: row.title,
@@ -1168,9 +1178,10 @@ export default async function handler(req, res) {
           needs_action_count: computed.needs_action_count,
           lifecycle_updated_at: clean(snapshot.lifecycle_updated_at || ''),
           source_counts: {
-            user_listings: userListingRows.length,
-            listings: legacyListingRows.length,
-            merged: rows.length
+            user_listings: listingSourceCounts.user_listings,
+            listings: listingSourceCounts.listings,
+            merged: rows.length,
+            other: listingSourceCounts.other
           }
         },
         recent_activity: recentListings.slice(0, 8).map((row) => ({
@@ -1189,9 +1200,10 @@ export default async function handler(req, res) {
           snapshot_active_listings: safeNumber(snapshot.active_listings ?? computed.active_listings, 0),
           lifecycle_updated_at: clean(snapshot.lifecycle_updated_at || ''),
           sources: {
-            user_listings: userListingRows.length,
-            listings: legacyListingRows.length,
-            merged: rows.length
+            user_listings: listingSourceCounts.user_listings,
+            listings: listingSourceCounts.listings,
+            merged: rows.length,
+            other: listingSourceCounts.other
           }
         },
         account_snapshot: {

--- a/api/get-user-listings.js
+++ b/api/get-user-listings.js
@@ -16,9 +16,94 @@ function listingIdentityKey(row) { const marketplace = clean(row.marketplace_lis
 function buildListingIntelligence(row = {}) { const postedValue = row.posted_at || row.created_at || row.updated_at || null; const postedTs = postedValue ? new Date(postedValue).getTime() : 0; const ageDays = postedTs > 0 ? Math.max(0, Math.floor((Date.now() - postedTs) / 86400000)) : 0; const views = safeNumber(row.views_count, 0); const messages = safeNumber(row.messages_count, 0); const status = normalizeStatus(row.status); const lifecycle = normalizeLifecycleStatus(row.lifecycle_status, row.review_bucket); const reviewBucket = normalizeReviewBucket(row.review_bucket); const staleLike = status === "stale" || lifecycle === "stale" || lifecycle === "review_delete" || reviewBucket === "removedvehicles"; const likelySold = lifecycle === "review_delete" || reviewBucket === "removedvehicles"; const activeLike = !["sold","deleted","inactive"].includes(status) && lifecycle !== "review_delete"; const highViewsNoMessages = activeLike && views >= 20 && messages === 0; const promoteNow = activeLike && views >= 20 && messages >= 1; const lowPerformance = activeLike && ageDays >= 7 && views < 5 && messages === 0; const weak = staleLike || lowPerformance; const needsAction = weak || highViewsNoMessages || lifecycle === "review_price_update" || reviewBucket === "pricechanges"; let recommendedAction = "Keep live"; if (likelySold) recommendedAction = "Check if sold or stale"; else if (lifecycle === "review_price_update" || reviewBucket === "pricechanges" || highViewsNoMessages) recommendedAction = "Review price"; else if (lifecycle === "review_new" || reviewBucket === "newvehicles") recommendedAction = "Review new listing"; else if (lowPerformance) recommendedAction = "Refresh title/photos"; else if (promoteNow) recommendedAction = "Promote now"; let predictedScore = 50; predictedScore += Math.min(views, 25); predictedScore += Math.min(messages * 18, 36); predictedScore -= Math.min(ageDays * 3, 24); if (highViewsNoMessages) predictedScore -= 8; if (weak) predictedScore -= 20; predictedScore = Math.max(0, Math.min(100, Math.round(predictedScore))); let contentScore = 60; if (clean(row.title).length >= 18) contentScore += 10; if (clean(row.stock_number)) contentScore += 5; if (clean(row.vin)) contentScore += 5; if (clean(row.exterior_color)) contentScore += 5; if (clean(row.body_style)) contentScore += 5; if (clean(row.fuel_type)) contentScore += 5; if (ageDays >= 7 && views < 5) contentScore -= 10; contentScore = Math.max(0, Math.min(100, Math.round(contentScore))); let postPriority = 35; if (!postedValue) postPriority += 28; if (lifecycle === "review_new" || reviewBucket === "newvehicles") postPriority += 24; if (views === 0 && messages === 0 && ageDays <= 2) postPriority += 12; postPriority = Math.max(0, Math.min(100, Math.round(postPriority))); let refreshPriority = 10; if (staleLike) refreshPriority += 45; if (lowPerformance) refreshPriority += 22; if (ageDays >= 7 && views < 8) refreshPriority += 14; if (messages > 0) refreshPriority -= 10; refreshPriority = Math.max(0, Math.min(100, Math.round(refreshPriority))); let priceReviewPriority = 8; if (highViewsNoMessages || lifecycle === "review_price_update" || reviewBucket === "pricechanges") priceReviewPriority += 52; if (views >= 10 && messages === 0) priceReviewPriority += 12; priceReviewPriority = Math.max(0, Math.min(100, Math.round(priceReviewPriority))); let opportunityScore = Math.round((predictedScore * 0.45) + Math.min(views, 30) + Math.min(messages * 15, 30)); if (staleLike) opportunityScore -= 18; if (highViewsNoMessages) opportunityScore -= 10; opportunityScore = Math.max(0, Math.min(100, opportunityScore)); let actionBucket = "low_priority"; if (priceReviewPriority >= 60 || refreshPriority >= 60 || lifecycle.startsWith("review")) actionBucket = "do_now"; else if (postPriority >= 60 || promoteNow || needsAction) actionBucket = "do_today"; else if (weak || opportunityScore >= 60) actionBucket = "watch"; return { age_days: ageDays, likely_sold: likelySold, promote_now: promoteNow, weak, needs_action: needsAction, recommended_action: recommendedAction, predicted_score: predictedScore, predicted_label: predictedScore >= 75 ? "High Performer" : predictedScore >= 55 ? "Likely Performer" : predictedScore < 35 ? "Low Probability" : "Uncertain", pricing_insight: highViewsNoMessages ? "Price may be limiting message conversion." : messages >= 2 ? "Pricing appears competitive." : "Pricing signal still developing.", content_score: contentScore, content_feedback: contentScore >= 80 ? "Listing structure looks strong." : contentScore >= 65 ? "Content is workable but could be tightened." : "Listing likely needs a stronger title and better detail signals.", popularity_score: messages * 1000 + views * 10 + (postedTs / 100000000), post_priority: postPriority, refresh_priority: refreshPriority, price_review_priority: priceReviewPriority, opportunity_score: opportunityScore, action_bucket: actionBucket, action_bucket_label: actionBucket === "do_now" ? "Do Now" : actionBucket === "do_today" ? "Do Today" : actionBucket === "watch" ? "Watch" : "Low Priority" }; }
 function normalizeListingRow(row = {}, source = "user_listings") { const normalized = { ...row, id: clean(row.id || ""), source_table: source, status: normalizeStatus(row.status), lifecycle_status: normalizeLifecycleStatus(row.lifecycle_status, row.review_bucket), review_bucket: normalizeReviewBucket(row.review_bucket), identity_key: listingIdentityKey(row), title: clean(row.title || ""), posted_at: row.posted_at || row.created_at || null, updated_at: row.updated_at || row.created_at || null, views_count: safeNumber(row.views_count, 0), messages_count: safeNumber(row.messages_count, 0), price: safeNumber(row.price, 0), mileage: safeNumber(row.mileage || row.kilometers || row.km, 0), body_style: clean(row.body_style || ""), make: clean(row.make || ""), model: clean(row.model || ""), trim: clean(row.trim || "") }; return { ...normalized, ...buildListingIntelligence(normalized) }; }
 function preferListingRow(current, incoming) { if (!current) return incoming; const currentScore = (current.source_table === "user_listings" ? 1000 : 0) + safeNumber(current.views_count) + safeNumber(current.messages_count) * 10 + new Date(current.updated_at || current.posted_at || 0).getTime() / 1000000000000; const incomingScore = (incoming.source_table === "user_listings" ? 1000 : 0) + safeNumber(incoming.views_count) + safeNumber(incoming.messages_count) * 10 + new Date(incoming.updated_at || incoming.posted_at || 0).getTime() / 1000000000000; return incomingScore >= currentScore ? { ...current, ...incoming } : { ...incoming, ...current }; }
-async function resolveUser({ userId, email }) { if (userId) { const { data, error } = await supabase.from("users").select("id,email").eq("id", userId).maybeSingle(); if (error) throw error; if (data) return data; } if (email) { const { data, error } = await supabase.from("users").select("id,email").ilike("email", email).order("created_at", { ascending: false }).limit(1).maybeSingle(); if (error) throw error; if (data) return data; } return null; }
-async function fetchTableRows(tableName, userId, email) { const rows = []; const seen = new Set(); async function run(mode) { let query = supabase.from(tableName).select("*").order("updated_at", { ascending: false }).limit(300); if (mode === "user" && userId) query = query.eq("user_id", userId); if (mode === "email" && email) query = query.ilike("email", email); const { data, error } = await query; if (error) throw error; for (const row of (Array.isArray(data) ? data : [])) { const key = clean(row?.id || "") || `${clean(row?.marketplace_listing_id || "")}|${clean(row?.posted_at || row?.created_at || "")}`; if (!key || seen.has(key)) continue; seen.add(key); rows.push(row); } } if (userId) await run("user"); if (email) await run("email"); return rows; }
+async function resolveIdentityCandidates({ userId, email, authUid = "" }) {
+  const userIds = new Set([clean(userId), clean(authUid)].filter(Boolean));
+  const emails = new Set([normalizeEmail(email)].filter(Boolean));
+  const matchedUsers = [];
+
+  async function collectFromQuery(queryBuilder) {
+    const { data, error } = await queryBuilder;
+    if (error) throw error;
+    for (const row of (Array.isArray(data) ? data : [])) {
+      matchedUsers.push(row);
+      if (clean(row?.id)) userIds.add(clean(row.id));
+      if (clean(row?.auth_user_id)) userIds.add(clean(row.auth_user_id));
+      if (normalizeEmail(row?.email)) emails.add(normalizeEmail(row.email));
+    }
+  }
+
+  if (clean(userId) || clean(authUid)) {
+    const ids = Array.from(new Set([clean(userId), clean(authUid)].filter(Boolean)));
+    await collectFromQuery(
+      supabase
+        .from("users")
+        .select("id,auth_user_id,email,created_at")
+        .or(ids.map((id) => `id.eq.${id},auth_user_id.eq.${id}`).join(","))
+        .order("created_at", { ascending: false })
+        .limit(20)
+    );
+  }
+
+  if (normalizeEmail(email)) {
+    await collectFromQuery(
+      supabase
+        .from("users")
+        .select("id,auth_user_id,email,created_at")
+        .ilike("email", normalizeEmail(email))
+        .order("created_at", { ascending: false })
+        .limit(20)
+    );
+  }
+
+  const primary = matchedUsers[0] || null;
+  return {
+    primary_user_id: clean(primary?.id || userId || authUid || ""),
+    primary_email: normalizeEmail(primary?.email || email || ""),
+    user_ids: Array.from(userIds),
+    emails: Array.from(emails)
+  };
+}
+
+async function fetchTableRows(tableName, userIds = [], emails = []) {
+  const rows = [];
+  const seen = new Set();
+
+  async function pushRows(query) {
+    const { data, error } = await query;
+    if (error) throw error;
+    for (const row of (Array.isArray(data) ? data : [])) {
+      const key = clean(row?.id || "") || `${clean(row?.marketplace_listing_id || "")}|${clean(row?.posted_at || row?.created_at || "")}`;
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      rows.push(row);
+    }
+  }
+
+  if (Array.isArray(userIds) && userIds.length) {
+    await pushRows(
+      supabase
+        .from(tableName)
+        .select("*")
+        .in("user_id", userIds)
+        .order("updated_at", { ascending: false })
+        .limit(300)
+    );
+  }
+
+  for (const email of (Array.isArray(emails) ? emails : []).filter(Boolean)) {
+    await pushRows(
+      supabase
+        .from(tableName)
+        .select("*")
+        .ilike("email", email)
+        .order("updated_at", { ascending: false })
+        .limit(300)
+    );
+  }
+
+  return rows;
+}
 function matchesFilter(row, { status, lifecycleStatus, reviewBucket, search, preset }) { const normalizedStatus = normalizeStatus(row.status); const normalizedLifecycle = normalizeLifecycleStatus(row.lifecycle_status, row.review_bucket); const normalizedBucket = normalizeReviewBucket(row.review_bucket); if (status) { if (status === "review") { if (!["review_delete", "review_price_update", "review_new"].includes(normalizedLifecycle)) return false; } else if (normalizedStatus !== status) return false; } if (lifecycleStatus && normalizedLifecycle !== lifecycleStatus) return false; if (reviewBucket && normalizedBucket !== reviewBucket) return false; if (preset) { if (preset === "review" && !["review_delete", "review_price_update", "review_new"].includes(normalizedLifecycle)) return false; if (preset === "stale" && !(normalizedStatus === "stale" || normalizedLifecycle === "stale" || normalizedLifecycle === "review_delete")) return false; if (preset === "price" && normalizedLifecycle !== "review_price_update" && normalizedBucket !== "pricechanges") return false; if (preset === "new" && normalizedLifecycle !== "review_new" && normalizedBucket !== "newvehicles") return false; if (preset === "active" && ["sold", "deleted", "inactive", "stale"].includes(normalizedStatus)) return false; if (preset === "promote" && !row.promote_now) return false; if (preset === "likely_sold" && !row.likely_sold) return false; if (preset === "weak" && !row.weak) return false; if (preset === "needs_action" && !row.needs_action) return false; } if (search) { const haystack = [row.title, row.make, row.model, row.trim, row.vin, row.stock_number, row.body_style, row.vehicle_type, row.exterior_color, row.fuel_type, row.location, row.lifecycle_status, row.review_bucket, row.source_url, row.predicted_label, row.recommended_action, row.pricing_insight].map((value) => clean(value).toLowerCase()).join(" "); if (!haystack.includes(search)) return false; } return true; }
 function sortRows(rows, sort) { const items = [...rows]; if (sort === "price_high") return items.sort((a, b) => safeNumber(b.price) - safeNumber(a.price)); if (sort === "price_low") return items.sort((a, b) => safeNumber(a.price) - safeNumber(b.price)); if (sort === "popular") return items.sort((a, b) => safeNumber(b.popularity_score) - safeNumber(a.popularity_score)); if (sort === "predicted") return items.sort((a, b) => safeNumber(b.predicted_score) - safeNumber(a.predicted_score)); return items.sort((a, b) => new Date(b.posted_at || b.updated_at || 0).getTime() - new Date(a.posted_at || a.updated_at || 0).getTime()); }
 
-export default async function handler(req, res) { res.setHeader("Content-Type", "application/json"); if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" }); try { const verifiedUser = await getVerifiedRequestUser(req); if (!verifiedUser?.id || !verifiedUser?.email) return res.status(401).json({ error: "Unauthorized" }); const userId = clean(verifiedUser.id || req.query?.userId || req.query?.user_id || ""); const email = normalizeEmail(verifiedUser.email || req.query?.email || ""); const status = clean(req.query?.status || "").toLowerCase(); const preset = clean(req.query?.preset || "").toLowerCase(); const lifecycleStatus = clean(req.query?.lifecycle_status || req.query?.lifecycleStatus || "").toLowerCase(); const reviewBucket = normalizeReviewBucket(req.query?.review_bucket || req.query?.reviewBucket || ""); const search = clean(req.query?.search || "").toLowerCase(); const sort = clean(req.query?.sort || "newest").toLowerCase(); const limit = Math.min(Math.max(Number(req.query?.limit || 100), 1), 300); const user = await resolveUser({ userId, email }); const finalUserId = clean(user?.id || userId || ""); const finalEmail = normalizeEmail(user?.email || email || ""); if (!finalUserId && !finalEmail) return res.status(400).json({ error: "Missing userId or email" }); const [userRows, legacyRows] = await Promise.all([fetchTableRows("user_listings", finalUserId, finalEmail), fetchTableRows("listings", finalUserId, finalEmail)]); const mergedMap = new Map(); for (const row of userRows) { const normalized = normalizeListingRow(row, "user_listings"); mergedMap.set(normalized.identity_key, preferListingRow(mergedMap.get(normalized.identity_key), normalized)); } for (const row of legacyRows) { const normalized = normalizeListingRow(row, "listings"); mergedMap.set(normalized.identity_key, preferListingRow(mergedMap.get(normalized.identity_key), normalized)); } let rows = [...mergedMap.values()].filter((row) => matchesFilter(row, { status, lifecycleStatus, reviewBucket, search, preset })); rows = sortRows(rows, sort).slice(0, limit); return res.status(200).json({ success: true, data: rows, meta: { total: rows.length, limit, sources: { user_listings: userRows.length, listings: legacyRows.length, merged: mergedMap.size } } }); } catch (error) { console.error("get-user-listings fatal error:", error); return res.status(500).json({ error: error.message || "Internal server error" }); } }
+export default async function handler(req, res) { res.setHeader("Content-Type", "application/json"); if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" }); try { const verifiedUser = await getVerifiedRequestUser(req); if (!verifiedUser?.id || !verifiedUser?.email) return res.status(401).json({ error: "Unauthorized" }); const userId = clean(verifiedUser.id || req.query?.userId || req.query?.user_id || ""); const email = normalizeEmail(verifiedUser.email || req.query?.email || ""); const status = clean(req.query?.status || "").toLowerCase(); const preset = clean(req.query?.preset || "").toLowerCase(); const lifecycleStatus = clean(req.query?.lifecycle_status || req.query?.lifecycleStatus || "").toLowerCase(); const reviewBucket = normalizeReviewBucket(req.query?.review_bucket || req.query?.reviewBucket || ""); const search = clean(req.query?.search || "").toLowerCase(); const sort = clean(req.query?.sort || "newest").toLowerCase(); const limit = Math.min(Math.max(Number(req.query?.limit || 100), 1), 300); const identity = await resolveIdentityCandidates({ userId, email, authUid: clean(verifiedUser.id || "") }); const finalUserId = clean(identity.primary_user_id || userId || ""); const finalEmail = normalizeEmail(identity.primary_email || email || ""); if (!finalUserId && !finalEmail) return res.status(400).json({ error: "Missing userId or email" }); const [userRows, legacyRows] = await Promise.all([fetchTableRows("user_listings", identity.user_ids, identity.emails), fetchTableRows("listings", identity.user_ids, identity.emails)]); const mergedMap = new Map(); for (const row of userRows) { const normalized = normalizeListingRow(row, "user_listings"); mergedMap.set(normalized.identity_key, preferListingRow(mergedMap.get(normalized.identity_key), normalized)); } for (const row of legacyRows) { const normalized = normalizeListingRow(row, "listings"); mergedMap.set(normalized.identity_key, preferListingRow(mergedMap.get(normalized.identity_key), normalized)); } let rows = [...mergedMap.values()].filter((row) => matchesFilter(row, { status, lifecycleStatus, reviewBucket, search, preset })); rows = sortRows(rows, sort).slice(0, limit); return res.status(200).json({ success: true, data: rows, meta: { total: rows.length, limit, identity: { primary_user_id: finalUserId, primary_email: finalEmail, user_ids_considered: identity.user_ids.length, emails_considered: identity.emails.length }, sources: { user_listings: userRows.length, listings: legacyRows.length, merged: mergedMap.size } } }); } catch (error) { console.error("get-user-listings fatal error:", error); return res.status(500).json({ error: error.message || "Internal server error" }); } }

--- a/api/profile.js
+++ b/api/profile.js
@@ -1,4 +1,5 @@
 import { supabase } from '../lib/supabase.js';
+import { randomUUID } from 'node:crypto';
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
@@ -30,6 +31,7 @@ export default async function handler(req, res) {
   }
 
   // Fallback: email from query or body
+  const requestedId = req.query.id || req.body?.id || req.body?.user_id || null;
   if (!email) {
     email = req.query.email || req.body?.email;
   }
@@ -49,6 +51,8 @@ export default async function handler(req, res) {
 
     if (authUid) {
       query = query.eq('id', authUid);
+    } else if (requestedId) {
+      query = query.eq('id', requestedId);
     } else {
       query = query.ilike('email', email);
     }
@@ -115,7 +119,7 @@ export default async function handler(req, res) {
           .ilike('email', email)
           .maybeSingle();
 
-        const profileId = userRow?.auth_user_id || crypto.randomUUID();
+        const profileId = userRow?.auth_user_id || requestedId || randomUUID();
         upsertData = { id: profileId, email, ...updates };
       }
     }

--- a/dashboard.js
+++ b/dashboard.js
@@ -331,6 +331,7 @@ function buildSystemState(overrideProfile = null, overrideSession = null) {
     summaryProfile.compliance_mode,
     province
   ));
+  const normalizedProvince = province || ((complianceMode === 'AB' || complianceMode === 'BC') ? complianceMode : '');
 
   const canonicalProfile = {
     ...summaryProfile,
@@ -370,7 +371,7 @@ function buildSystemState(overrideProfile = null, overrideSession = null) {
       storedProfile.city,
       summaryProfile.city
     ),
-    province,
+    province: normalizedProvince,
     phone: firstNonEmpty(
       profile.phone,
       formProfile.phone,
@@ -590,6 +591,15 @@ async function parseApiJson(response) {
   }
 }
 
+async function parseJsonWithDebug(response) {
+  const rawText = await response.text();
+  try {
+    return { ok: true, data: JSON.parse(rawText || '{}'), rawText };
+  } catch {
+    return { ok: false, data: null, rawText };
+  }
+}
+
 function openReadCopyModal({ title = "Read in Dashboard", subtitle = "Read this in the dashboard first, then copy only if needed.", eyebrow = "Dashboard Script", body = "" } = {}) {
   const modal = document.getElementById("readCopyModal");
   if (!modal) return;
@@ -655,6 +665,7 @@ function bindCreditActionButtons() {
 let dashboardListings = [];
 let filteredListings = [];
 let dashboardListingsMeta = { total: 0, source_counts: { user_listings: 0, listings: 0, merged: 0 }, used_summary_fallback: false, source: "api" };
+let dashboardListingsDiagnostics = { raw_rows: 0, normalized_rows: 0, dropped_rows: 0 };
 let listingQuickFilter = "all";
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -970,18 +981,20 @@ if (copyAffiliatePostBtn) {
           })
         });
 
-        const rawText = await response.text();
+        const parsed = await parseJsonWithDebug(response);
+        const requestId = response.headers.get("x-request-id") || "";
+        const responseMeta = `status=${response.status}${requestId ? ` req=${requestId}` : ""}`;
 
-        let data;
-        try {
-          data = JSON.parse(rawText);
-        } catch (parseError) {
-          console.error("[billing] Non-JSON response:", rawText);
-          throw new Error("Server error (non-JSON response)");
+        if (!parsed.ok) {
+          const preview = cleanText(parsed.rawText).slice(0, 200);
+          console.error("[billing] Non-JSON response:", parsed.rawText);
+          throw new Error(`Server error (non-JSON response, ${responseMeta})${preview ? `: ${preview}` : ""}`);
         }
 
+        const data = parsed.data || {};
+
         if (!response.ok) {
-          throw new Error(data.error || "Could not open billing portal.");
+          throw new Error(`${cleanText(data.error || "Could not open billing portal.")} (${responseMeta})`);
         }
 
         if (!data.url) {
@@ -1041,6 +1054,18 @@ if (copyAffiliatePostBtn) {
     });
   }
 
+  document.querySelectorAll("[data-filter]").forEach((button) => {
+    if (button.dataset.boundListingFilter === "true") return;
+    button.dataset.boundListingFilter = "true";
+    button.addEventListener("click", () => {
+      listingQuickFilter = clean(button.getAttribute("data-filter") || "all").toLowerCase() || "all";
+      document.querySelectorAll("[data-filter]").forEach((other) => {
+        other.classList.toggle("active", other === button);
+      });
+      applyListingFiltersAndRender();
+    });
+  });
+
   window.addEventListener("resize", debounce(() => {
     drawActivityChart(buildChartSeries());
   }, 150));
@@ -1072,11 +1097,16 @@ async function refreshDashboardState(forceFresh = false) {
 async function loadListingDashboardData(forceFresh = false) {
   try {
     dashboardSummary = await fetchDashboardSummary(forceFresh);
-    dashboardListings = await fetchUserListings(forceFresh);
+    const rawListings = await fetchUserListings(forceFresh);
 
-    dashboardListings = Array.isArray(dashboardListings)
-      ? dashboardListings.map(normalizeListingRecord).filter(Boolean)
+    dashboardListings = Array.isArray(rawListings)
+      ? rawListings.map(normalizeListingRecord).filter(Boolean)
       : [];
+    dashboardListingsDiagnostics = {
+      raw_rows: Array.isArray(rawListings) ? rawListings.length : 0,
+      normalized_rows: dashboardListings.length,
+      dropped_rows: Math.max((Array.isArray(rawListings) ? rawListings.length : 0) - dashboardListings.length, 0)
+    };
 
     if (!dashboardSummary) {
       dashboardSummary = buildDashboardSummaryFromListings(dashboardListings);
@@ -1094,6 +1124,7 @@ async function loadListingDashboardData(forceFresh = false) {
   } catch (error) {
     console.error("loadListingDashboardData error:", error);
     dashboardListings = [];
+    dashboardListingsDiagnostics = { raw_rows: 0, normalized_rows: 0, dropped_rows: 0 };
     dashboardSummary = buildDashboardSummaryFromListings(dashboardListings);
     filteredListings = [];
     setSystemStateFromSources(currentProfile, currentNormalizedSession);
@@ -1395,6 +1426,40 @@ function mergeSummaryWithListings(summary, listings) {
     sessionPostsToday,
     snapshotPostsToday
   );
+  const planFromSession = cleanText(currentNormalizedSession?.subscription?.plan || "");
+  const planFromPlanAccess = cleanText(summary?.plan_access?.plan_label || "");
+  const planFromSnapshot = cleanText(summary?.account_snapshot?.plan || "");
+  const statusFromSession = cleanText(currentNormalizedSession?.subscription?.status || "");
+  const statusFromSnapshot = cleanText(summary?.account_snapshot?.status || "");
+  const limitFromSession = numberOrZero(currentNormalizedSession?.subscription?.posting_limit);
+  const limitFromPlanAccess = numberOrZero(summary?.plan_access?.posting_limit);
+  const limitFromSnapshot = numberOrZero(summary?.account_snapshot?.posting_limit);
+  const remainingFromSession = numberOrZero(currentNormalizedSession?.subscription?.posts_remaining);
+  const remainingFromSnapshot = numberOrZero(summary?.account_snapshot?.posts_remaining);
+  const setupFromSummary = summary?.setup_status && Object.keys(summary.setup_status || {}).length > 0;
+
+  const canonicalAccess = {
+    plan: planFromSession || planFromPlanAccess || planFromSnapshot || "Founder Beta",
+    status: statusFromSession || statusFromSnapshot || "inactive",
+    posting_limit: limitFromSession || limitFromPlanAccess || limitFromSnapshot || 0,
+    posts_remaining: remainingFromSession || remainingFromSnapshot || 0
+  };
+
+  const stateProvenance = {
+    posts_today: bestPostsToday === snapshotPostsToday && snapshotPostsToday > 0
+      ? "summary.account_snapshot.posts_today"
+      : (bestPostsToday === sessionPostsToday && sessionPostsToday > 0
+        ? "session.subscription.posts_today"
+        : "computed.listings.posts_today"),
+    plan: planFromSession
+      ? "session.subscription.plan"
+      : (planFromPlanAccess ? "summary.plan_access.plan_label" : (planFromSnapshot ? "summary.account_snapshot.plan" : "default")),
+    status: statusFromSession ? "session.subscription.status" : (statusFromSnapshot ? "summary.account_snapshot.status" : "default"),
+    posting_limit: limitFromSession > 0
+      ? "session.subscription.posting_limit"
+      : (limitFromPlanAccess > 0 ? "summary.plan_access.posting_limit" : (limitFromSnapshot > 0 ? "summary.account_snapshot.posting_limit" : "default")),
+    setup_status: setupFromSummary ? "summary.setup_status" : "fallback"
+  };
 
   return {
     posts_today: bestPostsToday,
@@ -1414,6 +1479,8 @@ function mergeSummaryWithListings(summary, listings) {
     top_listing_title: clean(summary.top_listing_title || computed.top_listing_title || "None yet"),
     account_snapshot: summary.account_snapshot || {},
     setup_status: summary.setup_status || {},
+    canonical_access: canonicalAccess,
+    state_provenance: stateProvenance,
     manager_access: Boolean(summary.manager_access),
     action_center: summary.action_center || summary.daily_ops_queues || {},
     daily_ops_queues: summary.daily_ops_queues || summary.action_center || {},
@@ -1543,6 +1610,7 @@ function renderDashboardAnalytics() {
   setTextByIdForAll("kpiMessages", String(numberOrZero(dashboardSummary?.total_messages)));
   setTextByIdForAll("kpiPostsRemaining", String(numberOrZero(currentNormalizedSession?.subscription?.posts_remaining ?? dashboardSummary?.account_snapshot?.posts_remaining)));
   setTextByIdForAll("kpiDailyLimit", String(numberOrZero(currentNormalizedSession?.subscription?.posting_limit ?? dashboardSummary?.account_snapshot?.posting_limit)));
+  renderRevenueActionPanels();
 
   // lifecycle-ready safe no-op if ids do not exist yet
   setTextByIdForAll("kpiReviewQueue", String(numberOrZero(dashboardSummary?.review_queue_count)));
@@ -1567,6 +1635,43 @@ function renderDashboardAnalytics() {
   renderComplianceWorkspace();
   renderToolsWorkspace();
   drawActivityChart(buildChartSeries());
+}
+
+function updateListingFilterCounts() {
+  const rows = Array.isArray(dashboardListings) ? dashboardListings : [];
+  const countBy = (predicate) => rows.filter(predicate).length;
+  const counts = {
+    all: rows.length,
+    review: countBy((item) => {
+      const lifecycle = clean((item.lifecycle_status || "").toLowerCase());
+      const bucket = clean((item.review_bucket || "").toLowerCase()).replace(/[\s_-]+/g, "");
+      return ["review_delete", "review_price_update", "review_new"].includes(lifecycle) || ["removedvehicles", "pricechanges", "newvehicles"].includes(bucket);
+    }),
+    stale: countBy((item) => {
+      const lifecycle = clean((item.lifecycle_status || "").toLowerCase());
+      const bucket = clean((item.review_bucket || "").toLowerCase()).replace(/[\s_-]+/g, "");
+      const status = clean((item.status || "").toLowerCase());
+      return lifecycle === "stale" || status === "stale" || lifecycle === "review_delete" || bucket === "removedvehicles";
+    }),
+    price: countBy((item) => clean((item.lifecycle_status || "").toLowerCase()) === "review_price_update" || clean((item.review_bucket || "").toLowerCase()).replace(/[\s_-]+/g, "") === "pricechanges"),
+    new: countBy((item) => clean((item.lifecycle_status || "").toLowerCase()) === "review_new" || clean((item.review_bucket || "").toLowerCase()).replace(/[\s_-]+/g, "") === "newvehicles"),
+    weak: countBy((item) => Boolean(item.weak)),
+    needs_action: countBy((item) => Boolean(item.needs_action)),
+    promote: countBy((item) => Boolean(item.promote_now)),
+    likely_sold: countBy((item) => Boolean(item.likely_sold)),
+    active: countBy((item) => {
+      const status = clean((item.status || "").toLowerCase());
+      const lifecycle = clean((item.lifecycle_status || "").toLowerCase());
+      return !["sold", "deleted", "inactive", "stale"].includes(status) && lifecycle !== "review_delete";
+    })
+  };
+
+  document.querySelectorAll("[data-filter]").forEach((button) => {
+    const key = clean(button.getAttribute("data-filter") || "all").toLowerCase();
+    const base = clean(button.textContent || "");
+    const label = base.replace(/\s*\(\d+\)\s*$/, "");
+    button.textContent = `${label} (${numberOrZero(counts[key])})`;
+  });
 }
 
 
@@ -1940,6 +2045,7 @@ function renderAnalyticsHub() {
 }
 
 function applyListingFiltersAndRender() {
+  updateListingFilterCounts();
   const searchTerm = clean((document.getElementById("listingSearchInput")?.value || "").toLowerCase());
   const sortMode = clean(document.getElementById("listingSortSelect")?.value || "popular");
 
@@ -2054,6 +2160,7 @@ function renderListingDataState(listings = []) {
     statusEl.textContent = [
       `${mergedCount} listing${mergedCount === 1 ? "" : "s"} loaded.`,
       `Rows: user_listings ${numberOrZero(counts.user_listings)} • listings ${numberOrZero(counts.listings)} • merged ${numberOrZero(counts.merged || mergedCount)}.`,
+      `Normalize: raw ${numberOrZero(dashboardListingsDiagnostics.raw_rows)} • rendered ${numberOrZero(dashboardListingsDiagnostics.normalized_rows)} • dropped ${numberOrZero(dashboardListingsDiagnostics.dropped_rows)}.`,
       summary.lifecycle_updated_at ? `Last lifecycle sync: ${cleanText(summary.lifecycle_updated_at)}.` : ""
     ].filter(Boolean).join(" ");
   }
@@ -2721,8 +2828,12 @@ async function loadAccountData(user, forceFresh = false) {
     setTextByIdForAll("referralCode", referral);
     setTextByIdForAll("referralCodeAffiliate", referral);
 
-    setTextByIdForAll("planNameBilling", currentNormalizedSession?.subscription?.plan || "Founder Beta");
-    setTextByIdForAll("subscriptionStatusBilling", currentNormalizedSession?.subscription?.status || "inactive");
+    const summaryPlan = cleanText(dashboardSummary?.plan_access?.plan_label || dashboardSummary?.account_snapshot?.plan || "");
+    const summaryStatus = cleanText(dashboardSummary?.account_snapshot?.status || "");
+    const effectivePlanLabel = cleanText(currentNormalizedSession?.subscription?.plan || summaryPlan || "Founder Beta");
+    const effectiveStatusLabel = cleanText(currentNormalizedSession?.subscription?.status || summaryStatus || "inactive");
+    setTextByIdForAll("planNameBilling", effectivePlanLabel);
+    setTextByIdForAll("subscriptionStatusBilling", effectiveStatusLabel);
     setTextByIdForAll("affiliateDirectCommission", "20% recurring");
     setTextByIdForAll("affiliateTierOverride", "5% second level");
     setTextByIdForAll("affiliatePartnerType", "Founding Partner");
@@ -3018,11 +3129,13 @@ function persistProfileSnapshots(profileSnapshot, session) {
 function renderSetupSnapshot() {
   const snapshot = dashboardSummary?.account_snapshot || {};
   const setup = dashboardSummary?.setup_status || {};
+  const canonicalAccess = dashboardSummary?.canonical_access || {};
+  const provenance = dashboardSummary?.state_provenance || {};
   const canonicalProfile = getCanonicalProfileState();
   const subscription = getCanonicalSubscriptionState();
 
-  setTextByIdForAll("snapshotPostingLimit", String(Math.max(numberOrZero(snapshot.posting_limit), numberOrZero(subscription.posting_limit))));
-  setTextByIdForAll("snapshotPostsRemaining", String(Math.max(numberOrZero(snapshot.posts_remaining), numberOrZero(currentNormalizedSession?.subscription?.posts_remaining))));
+  setTextByIdForAll("snapshotPostingLimit", String(Math.max(numberOrZero(canonicalAccess.posting_limit), numberOrZero(snapshot.posting_limit), numberOrZero(subscription.posting_limit))));
+  setTextByIdForAll("snapshotPostsRemaining", String(Math.max(numberOrZero(canonicalAccess.posts_remaining), numberOrZero(snapshot.posts_remaining), numberOrZero(currentNormalizedSession?.subscription?.posts_remaining))));
   setTextByIdForAll("snapshotPostsUsed", String(Math.max(numberOrZero(snapshot.posts_today ?? snapshot.posts_used_today), numberOrZero(currentNormalizedSession?.subscription?.posts_today), numberOrZero(dashboardSummary?.posts_today))));
   setTextByIdForAll("snapshotBillingSource", clean(currentNormalizedSession?.subscription?.billing_source || snapshot.billing_source || "subscriptions/users") || "subscriptions/users");
   setTextByIdForAll("snapshotCurrentPeriodEnd", formatShortDate(snapshot.current_period_end || currentNormalizedSession?.subscription?.current_period_end || ""));
@@ -3044,7 +3157,15 @@ function renderSetupSnapshot() {
         setup.compliance_mode_present ? null : "compliance mode missing"
       ].filter(Boolean);
 
-  setStatus("snapshotSetupSummary", summaryBits.length ? `Setup gaps: ${summaryBits.join(" • ")}` : "Account setup looks complete for beta use.");
+  const sourceBits = [
+    provenance.plan ? `plan=${provenance.plan}` : "",
+    provenance.posting_limit ? `limit=${provenance.posting_limit}` : "",
+    provenance.setup_status ? `setup=${provenance.setup_status}` : ""
+  ].filter(Boolean);
+  setStatus(
+    "snapshotSetupSummary",
+    `${summaryBits.length ? `Setup gaps: ${summaryBits.join(" • ")}` : "Account setup looks complete for beta use."}${sourceBits.length ? ` (sources: ${sourceBits.join(" | ")})` : ""}`
+  );
 }
 
 function renderAccessState(session) {

--- a/docs/testing-fix-roadmap.md
+++ b/docs/testing-fix-roadmap.md
@@ -1,0 +1,70 @@
+# Dashboard Reliability Roadmap (10 Phases)
+
+## Constraints
+- Keep the API surface at **12 endpoints max**; prefer extending existing responses over adding endpoints.
+- Prioritize the current blocker: **profile info not syncing from Supabase into the client dashboard**.
+
+## Phase 1 — Stabilize summary payloads (immediate)
+- Fix server-side runtime breakers in `/api/get-dashboard-summary` so the dashboard always receives a valid payload.
+- Add source-count safeguards so merged listing stats never reference undefined variables.
+- Outcome: dashboard boot path no longer silently falls back due to 500s.
+
+## Phase 2 — Establish profile source of truth
+- Make `profiles` table the canonical write/read layer for dashboard profile fields.
+- Ensure `/api/profile` GET and POST return a consistent shape (`{ profile }` and `updated_at`).
+- Remove field drift between `account_snapshot`, `profile_snapshot`, and localStorage fallback.
+
+## Phase 3 — Identity hardening for sync correctness
+- Enforce user resolution precedence as: verified auth UID -> users.id -> normalized email fallback.
+- Audit all profile/account endpoints to ensure same identity strategy (no mixed casing or alternate email aliases).
+- Add debug markers to responses (`identity_source`, `matched_by`) for faster triage.
+
+## Phase 4 — Client hydration determinism
+- Refactor dashboard boot sequence to hydrate profile in one deterministic pass:
+  1. session,
+  2. account/session summary,
+  3. profile,
+  4. render.
+- Prevent stale local snapshot from overriding fresh Supabase profile unless API fails.
+- Add explicit "remote vs local" status message in setup panel.
+
+## Phase 5 — Write-path verification and optimistic UI
+- After profile save, re-read server profile and diff returned fields against form values.
+- Surface field-level sync errors (e.g., invalid URL normalization, missing write permissions).
+- Keep optimistic UI but rollback individual fields when server rejects updates.
+
+## Phase 6 — Database and RLS validation
+- Verify Supabase RLS allows authenticated users to read/write their own profile row by `id` and intended email fallback logic.
+- Confirm indexes for `profiles.id`, `profiles.email`, `subscriptions.user_id`, `posting_usage(user_id,date_key)`.
+- Add migration notes for required nullable/non-null profile fields.
+
+## Phase 7 — Observability and diagnostics
+- Add structured logs for dashboard-critical endpoints (`profile`, `extension-state`, `get-dashboard-summary`) with request IDs.
+- Add lightweight sync diagnostics in UI (last profile sync timestamp + source endpoint).
+- Create a reproducible "profile sync smoke test" script for local and production checks.
+
+## Phase 8 — API budget and consolidation (12 max)
+- Keep current 12 APIs; do not add net-new endpoints.
+- Consolidate overlapping data inside existing endpoints:
+  - `/api/get-dashboard-summary` as main read aggregator,
+  - `/api/profile` as profile write/read,
+  - `/api/extension-state` for extension compatibility only.
+- De-duplicate repeated subscription/profile fetch logic in shared helpers.
+
+## Phase 9 — Automated test coverage
+- Add integration tests for:
+  - profile save -> reload -> dashboard render roundtrip,
+  - UID-based identity and email fallback behavior,
+  - no-regression for account snapshot/profile snapshot hydration.
+- Add contract tests asserting required response keys used by `dashboard.js`.
+
+## Phase 10 — Performance + rollout safety
+- Introduce staged rollout flags for sync-path changes.
+- Add cache-busting controls only where needed (`_ts`) and avoid over-fetching on routine navigation.
+- Define rollback playbook and owner checklist for production incident handling.
+
+## Immediate next execution order
+1. Phase 1 + Phase 4 smoke validation.
+2. Phase 2 + Phase 3 identity/profile normalization.
+3. Phase 5 + Phase 7 visibility improvements.
+4. Phase 9 tests before broader refactors in Phase 8/10.

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables.');
+}
+
+export const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: {
+    persistSession: false,
+    autoRefreshToken: false
+  }
+});


### PR DESCRIPTION
### Motivation
- Harden identity resolution and profile sync so dashboard and APIs consistently resolve users by auth UID, users table, or normalized email and avoid stale/fallback drift.
- Add request-level observability and diagnostics to aid troubleshooting of billing, listing hydration, and profile writes.
- Consolidate Supabase client usage and make listing merging/deduplication and source counts more deterministic.
- Surface useful client-side diagnostics and safer parsing for API responses to reduce silent failures in the UI.

### Description
- Add request tracing to `/api/create-billing-portal-session` by generating an `x-request-id` and returning `request_id` in JSON error/success responses and include it in client error messages. 
- Refactor `/api/get-user-listings` to robustly resolve candidate identities via `resolveIdentityCandidates`, expand `fetchTableRows` to accept multiple `user_ids`/`emails`, deduplicate rows, and return identity metadata in the response `meta` payload. 
- Update `/api/get-dashboard-summary` to compute `listingSourceCounts`, expose `canonical_access` and `state_provenance` for deterministic access/plan selection, and respect a testing override mode for posting limits. 
- Modify `/api/extension-state` to normalize emails, support a set of `ACCESS_OVERRIDE_EMAILS` for forced access during testing, and increase limits when overridden. 
- Enhance `/api/profile` to accept an explicit `id` param for GET and to use the requested id (or a stable UUID) when creating profiles so writes without auth UID upsert predictably, and import `randomUUID` for stable IDs. 
- Add a shared `lib/supabase.js` exporting a single Supabase service-role client and update server code to use it. 
- Update client `dashboard.js` to add `parseJsonWithDebug`, include request id in billing error flows, collect listing hydration diagnostics, bind additional listing filter UI, render derived `canonical_access`, and improve snapshot provenance messaging. 
- Add `docs/testing-fix-roadmap.md` with a 10-phase reliability roadmap for dashboard/profile fixes and rollout guidance.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc92600a5083259683ea3ad9bd7de9)