### PR TITLE
Fix Phase 5 boot syntax error

### DIFF
--- a/dashboard-phase4-boot.js
+++ b/dashboard-phase4-boot.js
@@ -3,9 +3,10 @@
   if (NS.modules?.phase4boot) return;
 
   function loadPhase5Workflow() {
-    const src = "/dashboard-phase5-workflow.js?v=20260403pr1";
+    const src = "/dashboard-phase5-workflow.js?v=20260403pr2";
     const existing = Array.from(document.scripts).find((s) => s.src && s.src.includes("/dashboard-phase5-workflow.js"));
     if (existing) return Promise.resolve();
+
     return new Promise((resolve, reject) => {
       const script = document.createElement("script");
       script.src = src;
@@ -19,18 +20,22 @@
   async function boot() {
     try {
       NS.overview?.applyOverviewHierarchy?.();
+
       await loadPhase5Workflow().catch((error) => {
         console.warn("[Elevate Dashboard] Phase 5 workflow load warning:", error);
       });
+
       NS.phase5workflow?.renderSalesOS?.();
-      if (NS.events) {
+
+      if (NS.events && !NS.__phase5StateListenerBound) {
+        NS.__phase5StateListenerBound = true;
         NS.events.addEventListener("state:set", () => {
-          try { NS.phase5workflow?.renderSalesOS?.(); } catch {}
+          try {
+            NS.phase5workflow?.renderSalesOS?.();
+          } catch {}
         });
       }
-  function boot() {
-    try {
-      NS.overview?.applyOverviewHierarchy?.();
+
       if (NS.state) NS.state.set("booted", true);
     } catch (error) {
       console.warn("[Elevate Dashboard] Phase 4 boot warning:", error);
@@ -38,7 +43,6 @@
   }
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", () => { boot(); });
     document.addEventListener("DOMContentLoaded", boot);
   } else {
     boot();


### PR DESCRIPTION
## Summary
- fix the syntax error in `dashboard-phase4-boot.js`
- remove the accidental duplicated `boot()` block introduced in the previous merge
- keep the Phase 5 Sales OS workflow layer loading as intended

## Why
The merged Phase 5 change introduced a malformed `try` block in `dashboard-phase4-boot.js`, which caused:
- `Uncaught SyntaxError: Missing catch or finally after try`
- dashboard boot stopping before user/session hydration could complete

## What changed
- restored a single valid `boot()` implementation
- preserved lazy loading of `dashboard-phase5-workflow.js`
- added a one-time listener guard for the Phase 5 state listener

## Result
- dashboard should boot normally again
- Phase 5 Sales OS layer should still render on top of the current runtime