### PR TITLE
Dashboard stabilization bundle 1: safe mode, boot hardening, and phase-5 isolation

### DIFF
--- a/stabilization/bundle-1/README.md
+++ b/stabilization/bundle-1/README.md
@@ -1,0 +1,62 @@
+# Dashboard Stabilization Bundle 1
+
+This bundle is the first website-side stabilization pass for the Elevate Automation dashboard.
+
+## What is included
+
+This bundle groups the highest-priority website phases into one implementation set:
+
+1. **P0 runtime stabilization**
+   - remove the most likely phase-5/state render loop source
+   - stop synthetic bootstrap recursion patterns
+   - keep the dashboard functional even when Sales OS is disabled
+
+2. **Single-path boot hardening**
+   - cleaner loader flags
+   - safer boot telemetry
+   - safe-mode entry point
+
+3. **Phase 5 workflow isolation**
+   - render Sales OS without writing back into state during render
+   - only rerender on targeted state changes
+
+4. **Operational recovery path**
+   - `?safe=1` support
+   - safe mode disables phase 5 workflow while keeping the core dashboard alive
+
+## Files in this bundle
+
+Copy these files over the matching root files in the repo:
+
+- `stabilization/bundle-1/dashboard.js` -> `/dashboard.js`
+- `stabilization/bundle-1/dashboard-bootstrap.js` -> `/dashboard-bootstrap.js`
+- `stabilization/bundle-1/dashboard-phase4-boot.js` -> `/dashboard-phase4-boot.js`
+- `stabilization/bundle-1/dashboard-phase5-workflow.js` -> `/dashboard-phase5-workflow.js`
+
+## Expected outcome
+
+After applying these replacements:
+
+- the dashboard should stop freezing on initial load from the current phase-5 render loop path
+- the page should have a recoverable safe mode
+- boot telemetry should stay visible without redispatching `DOMContentLoaded`
+- Sales OS should behave as a rendering layer rather than a render-triggering state writer
+
+## Suggested test order
+
+1. Open `/dashboard.html?safe=1`
+2. Confirm the core dashboard loads without freezing
+3. Open `/dashboard.html`
+4. Confirm the dashboard loads and Sales OS appears under the overview command center
+5. Switch Sales OS mode and role selectors
+6. Confirm the page does not enter a loading loop or browser hang
+
+## Notes
+
+This bundle is intentionally focused on **stability first**, not full architecture cleanup.
+The next bundle should handle:
+
+- legacy boot extraction
+- summary endpoint decomposition
+- route/module separation
+- setup wizard rebuild

--- a/stabilization/bundle-1/dashboard-bootstrap.js
+++ b/stabilization/bundle-1/dashboard-bootstrap.js
@@ -1,0 +1,253 @@
+(() => {
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  if (NS.modules?.bootstrap) return;
+
+  const RETRY_TIMEOUT_MS = 15000;
+  const POLL_MS = 500;
+
+  const CSS = `
+    .ea-boot-panel {
+      margin: 12px 0 18px;
+      padding: 14px 16px;
+      border: 1px solid rgba(212,175,55,0.14);
+      border-radius: 14px;
+      background: rgba(255,255,255,0.02);
+      display: grid;
+      gap: 8px;
+    }
+    .ea-boot-panel-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .ea-boot-eyebrow {
+      color: #d4af37;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    .ea-boot-badge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      padding: 0 10px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 700;
+      border: 1px solid rgba(255,255,255,0.08);
+      background: #171717;
+      color: #f4f4f4;
+    }
+    .ea-boot-badge.running { color: #f3ddb0; border-color: rgba(212,175,55,0.18); }
+    .ea-boot-badge.ready { color: #9de8a8; border-color: rgba(157,232,168,0.22); }
+    .ea-boot-badge.error { color: #ffb4b4; border-color: rgba(255,180,180,0.2); }
+    .ea-boot-title { font-size: 14px; font-weight: 700; }
+    .ea-boot-detail { font-size: 13px; color: #b8b8b8; line-height: 1.5; }
+    .ea-boot-stage-list { display: grid; gap: 6px; }
+    .ea-boot-stage-item { font-size: 12px; color: #d6d6d6; }
+    .ea-boot-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+    .ea-boot-actions button {
+      appearance: none;
+      border: 1px solid rgba(255,255,255,0.08);
+      background: #1a1a1a;
+      color: #f2f2f2;
+      border-radius: 10px;
+      padding: 10px 12px;
+      cursor: pointer;
+      font-size: 12px;
+    }
+  `;
+
+  function qs(selector, root = document) {
+    return root.querySelector(selector);
+  }
+
+  function clean(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function injectStyles() {
+    if (document.getElementById('ea-boot-panel-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'ea-boot-panel-styles';
+    style.textContent = CSS;
+    document.head.appendChild(style);
+  }
+
+  function openSafeMode() {
+    const url = new URL(window.location.href);
+    url.searchParams.set('safe', '1');
+    window.location.href = url.toString();
+  }
+
+  function reloadPage() {
+    window.location.reload();
+  }
+
+  function retryBootstrap() {
+    if (typeof window.__ELEVATE_DASHBOARD_LEGACY_BOOT__ === 'function') {
+      try {
+        window.__ELEVATE_DASHBOARD_LEGACY_BOOT__();
+      } catch (error) {
+        console.warn('[Elevate Dashboard] retry bootstrap warning:', error);
+      }
+    }
+    if (NS.phase5workflow?.renderSalesOS && !NS.flags?.disablePhase5) {
+      try {
+        NS.phase5workflow.renderSalesOS({ reason: 'manual_retry' });
+      } catch (error) {
+        console.warn('[Elevate Dashboard] phase5 retry warning:', error);
+      }
+    }
+  }
+
+  function ensurePanel() {
+    injectStyles();
+    let panel = document.getElementById('eaBootPanel');
+    if (panel) return panel;
+
+    panel = document.createElement('div');
+    panel.id = 'eaBootPanel';
+    panel.className = 'ea-boot-panel';
+    panel.innerHTML = `
+      <div class="ea-boot-panel-head">
+        <div>
+          <div class="ea-boot-eyebrow">Boot Telemetry</div>
+          <div id="eaBootTitle" class="ea-boot-title">Starting dashboard bootstrap...</div>
+        </div>
+        <div id="eaBootBadge" class="ea-boot-badge running">Running</div>
+      </div>
+      <div id="eaBootDetail" class="ea-boot-detail">Preparing telemetry and startup controller.</div>
+      <div id="eaBootStages" class="ea-boot-stage-list"></div>
+      <div class="ea-boot-actions">
+        <button id="eaBootRetryBtn" type="button">Retry bootstrap</button>
+        <button id="eaBootSafeBtn" type="button">Open safe mode</button>
+        <button id="eaBootReloadBtn" type="button">Reload page</button>
+      </div>
+    `;
+
+    const header = qs('.main-header') || document.body;
+    header.insertAdjacentElement('afterend', panel);
+
+    document.getElementById('eaBootRetryBtn')?.addEventListener('click', retryBootstrap);
+    document.getElementById('eaBootSafeBtn')?.addEventListener('click', openSafeMode);
+    document.getElementById('eaBootReloadBtn')?.addEventListener('click', reloadPage);
+
+    return panel;
+  }
+
+  function renderStages(stages = []) {
+    const wrap = document.getElementById('eaBootStages');
+    if (!wrap) return;
+    wrap.innerHTML = stages.slice(-6).map((line) => `<div class="ea-boot-stage-item">• ${line}</div>`).join('');
+  }
+
+  function updatePanel(status, title, detail) {
+    ensurePanel();
+    const badge = document.getElementById('eaBootBadge');
+    const titleEl = document.getElementById('eaBootTitle');
+    const detailEl = document.getElementById('eaBootDetail');
+    if (badge) {
+      badge.className = `ea-boot-badge ${status}`;
+      badge.textContent = status === 'ready' ? 'Ready' : status === 'error' ? 'Error' : 'Running';
+    }
+    if (titleEl) titleEl.textContent = title || 'Boot status';
+    if (detailEl) detailEl.textContent = detail || '';
+    const bootStatus = document.getElementById('bootStatus');
+    if (bootStatus) bootStatus.textContent = detail || title || '';
+  }
+
+  function pushStage(label, detail = '') {
+    NS.bootstrapState = NS.bootstrapState || { stages: [] };
+    const line = detail ? `${label}: ${detail}` : label;
+    NS.bootstrapState.stages.push(line);
+    renderStages(NS.bootstrapState.stages);
+    updatePanel('running', label, detail);
+  }
+
+  function getIndicators() {
+    const userEmailText = clean(qs('.user-email')?.textContent || '');
+    const welcomeText = clean(document.getElementById('welcomeText')?.textContent || '');
+    return {
+      shellLoading: /loading/i.test(userEmailText) || /loading dashboard/i.test(welcomeText),
+      hasUser: Boolean(window.currentUser?.id) || (userEmailText && !/loading/i.test(userEmailText)),
+      hasSession: Boolean(window.currentNormalizedSession?.subscription || window.currentAccountData),
+      hasSummary: Boolean(window.dashboardSummary && typeof window.dashboardSummary === 'object'),
+      hasListings: Array.isArray(window.dashboardListings) && window.dashboardListings.length > 0
+    };
+  }
+
+  function maybeRenderPhase5() {
+    if (NS.flags?.disablePhase5) return;
+    try {
+      NS.phase5workflow?.renderSalesOS?.({ reason: 'bootstrap_watch' });
+    } catch (error) {
+      console.warn('[Elevate Dashboard] phase5 render warning:', error);
+    }
+  }
+
+  function startWatch() {
+    ensurePanel();
+    pushStage('Bootstrap', NS.flags?.safeMode
+      ? 'Safe mode active. Watching core dashboard hydration only.'
+      : 'Watching shell hydration and data readiness.');
+
+    const startedAt = Date.now();
+
+    const tick = () => {
+      const indicators = getIndicators();
+
+      if (indicators.hasUser && !indicators.hasSummary) {
+        updatePanel('running', 'User resolved', 'Waiting for dashboard summary and workspace hydration.');
+      }
+
+      if (indicators.hasSummary && !indicators.hasSession) {
+        updatePanel('running', 'Summary resolved', 'Waiting for normalized session and section render pass.');
+      }
+
+      if (indicators.hasSummary && indicators.hasSession) {
+        maybeRenderPhase5();
+      }
+
+      if (!indicators.shellLoading && indicators.hasUser && indicators.hasSummary && indicators.hasSession) {
+        pushStage('Ready', 'Core dashboard hydration completed.');
+        updatePanel(
+          'ready',
+          'Dashboard hydrated',
+          NS.flags?.safeMode
+            ? 'Core dashboard is available in safe mode.'
+            : (indicators.hasListings ? 'Workspace, summary, and listings are available.' : 'Workspace and summary are available. Listings may still be hydrating.')
+        );
+        clearInterval(intervalId);
+        return;
+      }
+
+      if (Date.now() - startedAt > RETRY_TIMEOUT_MS) {
+        updatePanel('error', 'Bootstrap stalled', 'Shell is still partially loaded. Try Retry bootstrap or Safe mode.');
+        clearInterval(intervalId);
+      }
+    };
+
+    const intervalId = setInterval(tick, POLL_MS);
+    tick();
+  }
+
+  function boot() {
+    if (NS.bootstrapState?.started) return;
+    NS.bootstrapState = NS.bootstrapState || {};
+    NS.bootstrapState.started = true;
+    startWatch();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+
+  NS.modules = NS.modules || {};
+  NS.modules.bootstrap = true;
+})();

--- a/stabilization/bundle-1/dashboard-phase4-boot.js
+++ b/stabilization/bundle-1/dashboard-phase4-boot.js
@@ -1,0 +1,100 @@
+(() => {
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  if (NS.modules?.phase4boot) return;
+
+  let phase5ScriptPromise = null;
+  let renderTimer = null;
+  let renderInFlight = false;
+
+  function shouldRenderForPath(path = '') {
+    const normalized = String(path || '');
+    return [
+      'booted',
+      'workflow.mode',
+      'workflow.role',
+      'ui.activeSection',
+      'summary',
+      'listings',
+      'filteredListings'
+    ].includes(normalized);
+  }
+
+  function loadPhase5Workflow() {
+    if (NS.flags?.disablePhase5) return Promise.resolve();
+    if (phase5ScriptPromise) return phase5ScriptPromise;
+
+    const src = '/dashboard-phase5-workflow.js?v=20260406-stab1';
+    const existing = Array.from(document.scripts).find((script) => script.src && script.src.includes('/dashboard-phase5-workflow.js'));
+    if (existing) {
+      phase5ScriptPromise = Promise.resolve();
+      return phase5ScriptPromise;
+    }
+
+    phase5ScriptPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = false;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error(`Failed to load ${src}`));
+      document.head.appendChild(script);
+    });
+
+    return phase5ScriptPromise;
+  }
+
+  function queuePhase5Render(reason = 'boot') {
+    if (NS.flags?.disablePhase5) return;
+    if (renderInFlight) return;
+
+    clearTimeout(renderTimer);
+    renderTimer = window.setTimeout(() => {
+      renderInFlight = true;
+      try {
+        NS.phase5workflow?.renderSalesOS?.({ reason });
+      } catch (error) {
+        console.warn('[Elevate Dashboard] Phase 5 render warning:', error);
+      } finally {
+        renderInFlight = false;
+      }
+    }, 60);
+  }
+
+  async function boot() {
+    try {
+      if (!NS.flags?.disableOverviewHierarchy) {
+        NS.overview?.applyOverviewHierarchy?.();
+      }
+
+      await loadPhase5Workflow().catch((error) => {
+        console.warn('[Elevate Dashboard] Phase 5 workflow load warning:', error);
+      });
+
+      queuePhase5Render('phase4_boot');
+
+      if (NS.events && !NS.__phase5StateListenerBound) {
+        NS.__phase5StateListenerBound = true;
+        NS.events.addEventListener('state:set', (event) => {
+          const path = event?.detail?.path || '';
+          if (shouldRenderForPath(path)) {
+            queuePhase5Render(path);
+          }
+        });
+      }
+
+      if (NS.state && !NS.state.get?.('booted')) {
+        NS.state.set('booted', true);
+      }
+    } catch (error) {
+      console.warn('[Elevate Dashboard] Phase 4 boot warning:', error);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+
+  NS.modules = NS.modules || {};
+  NS.modules.phase4boot = true;
+})();

--- a/stabilization/bundle-1/dashboard-phase5-workflow.js
+++ b/stabilization/bundle-1/dashboard-phase5-workflow.js
@@ -1,0 +1,334 @@
+(() => {
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  if (NS.modules?.phase5workflow) return;
+
+  const CSS = `
+    .salesos-shell { display:grid; gap:16px; margin-bottom:16px; }
+    .salesos-bar { display:grid; grid-template-columns: 1.15fr 1fr; gap:16px; }
+    .salesos-card { background:#121212; border:1px solid rgba(212,175,55,0.12); border-radius:18px; padding:18px; box-shadow:0 10px 30px rgba(0,0,0,0.28); }
+    .salesos-eyebrow { color:#d4af37; font-size:12px; font-weight:700; letter-spacing:1.3px; text-transform:uppercase; margin-bottom:8px; }
+    .salesos-title { font-size:24px; font-weight:700; line-height:1.1; margin-bottom:8px; }
+    .salesos-sub { color:#b8b8b8; font-size:14px; line-height:1.55; }
+    .salesos-chip-row { display:flex; gap:8px; flex-wrap:wrap; margin-top:14px; }
+    .salesos-chip { display:inline-flex; align-items:center; min-height:34px; padding:0 12px; border-radius:999px; background:rgba(212,175,55,0.10); border:1px solid rgba(212,175,55,0.16); color:#f3ddb0; font-size:12px; font-weight:700; }
+    .salesos-controls { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
+    .salesos-select { background:#171717; color:#f5f5f5; border:1px solid rgba(255,255,255,0.08); border-radius:12px; padding:12px 14px; font-size:14px; min-width:160px; }
+    .salesos-grid { display:grid; grid-template-columns: 1.35fr 0.95fr; gap:16px; }
+    .salesos-queue { display:grid; gap:12px; }
+    .salesos-task { background:#161616; border:1px solid rgba(255,255,255,0.06); border-radius:16px; padding:14px; display:grid; gap:10px; }
+    .salesos-task-head { display:flex; justify-content:space-between; align-items:flex-start; gap:12px; }
+    .salesos-task-title { font-size:15px; font-weight:700; line-height:1.35; }
+    .salesos-task-meta { color:#a7a7a7; font-size:12px; line-height:1.4; }
+    .salesos-priority { display:inline-flex; align-items:center; padding:6px 10px; border-radius:999px; font-size:11px; font-weight:700; letter-spacing:0.06em; text-transform:uppercase; border:1px solid rgba(255,255,255,0.08); }
+    .salesos-priority.do_now { background:rgba(212,175,55,0.14); color:#f3ddb0; border-color:rgba(212,175,55,0.2); }
+    .salesos-priority.do_today { background:rgba(255,255,255,0.06); color:#ececec; }
+    .salesos-priority.watch { background:rgba(56,122,255,0.12); color:#cfe0ff; border-color:rgba(56,122,255,0.18); }
+    .salesos-priority.low { background:rgba(120,120,120,0.14); color:#d7d7d7; }
+    .salesos-task-copy { color:#ececec; font-size:13px; line-height:1.55; }
+    .salesos-task-actions { display:flex; gap:8px; flex-wrap:wrap; }
+    .salesos-btn { appearance:none; border:1px solid rgba(255,255,255,0.08); background:#1a1a1a; color:#f2f2f2; border-radius:12px; padding:10px 12px; cursor:pointer; font-size:13px; }
+    .salesos-btn.primary { background:#d4af37; color:#0b0b0b; border:none; font-weight:700; }
+    .salesos-side-list { display:grid; gap:10px; }
+    .salesos-side-item { background:#171717; border:1px solid rgba(255,255,255,0.06); border-radius:14px; padding:12px; }
+    .salesos-empty { padding:18px; border-radius:16px; border:1px dashed rgba(212,175,55,0.18); color:#a9a9a9; background:#111; text-align:center; }
+    @media (max-width: 1180px) {
+      .salesos-bar, .salesos-grid { grid-template-columns: 1fr; }
+    }
+  `;
+
+  function n(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : 0;
+  }
+
+  function clean(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function formatPriority(priority) {
+    const normalized = clean(priority).toLowerCase();
+    if (normalized === 'do_now') return { key: 'do_now', label: 'Do Now' };
+    if (normalized === 'do_today') return { key: 'do_today', label: 'Do Today' };
+    if (normalized === 'watch') return { key: 'watch', label: 'Watch' };
+    return { key: 'low', label: 'Low' };
+  }
+
+  function inferRole(summary = {}) {
+    if (summary.manager_access) return 'manager';
+    if ((summary.affiliate || {}).referral_code) return 'hybrid';
+    return 'salesperson';
+  }
+
+  function buildWorkflowTasks(summary = {}) {
+    const tasks = [];
+    const actionDetails = summary.action_center_details || {};
+    const revenue = summary.revenue_intelligence || {};
+    const setup = summary.setup_status || {};
+
+    const todayItems = Array.isArray(actionDetails.today) ? actionDetails.today : [];
+    todayItems.forEach((item, index) => {
+      tasks.push({
+        id: clean(item.id || `today_${index}`),
+        title: clean(item.title || item.label || 'Priority task'),
+        copy: clean(item.copy || item.description || item.reason || 'Review this task.'),
+        priority: 'do_now',
+        source: 'action_center',
+        action: clean(item.action || ''),
+        section: 'overview'
+      });
+    });
+
+    const stale = n(summary.stale_listings);
+    if (stale > 0) {
+      tasks.push({
+        id: 'stale_refresh',
+        title: `${stale} stale listing${stale === 1 ? '' : 's'} need refresh`,
+        copy: 'Move stale inventory into the first recovery pass so visibility and repost flow do not lag.',
+        priority: stale >= 10 ? 'do_now' : 'do_today',
+        source: 'listing_health',
+        action: 'stale',
+        section: 'overview'
+      });
+    }
+
+    const reviewQueue = n(summary.review_queue_count);
+    if (reviewQueue > 0) {
+      tasks.push({
+        id: 'review_queue',
+        title: `${reviewQueue} listing${reviewQueue === 1 ? '' : 's'} waiting for review`,
+        copy: 'Clear review friction first so the queue does not slow the operating loop.',
+        priority: reviewQueue >= 10 ? 'do_now' : 'do_today',
+        source: 'review_queue',
+        action: 'review',
+        section: 'overview'
+      });
+    }
+
+    const setupGaps = Array.isArray(setup.setup_gaps) ? setup.setup_gaps.filter(Boolean) : [];
+    if (setupGaps.length) {
+      tasks.push({
+        id: 'setup_gap',
+        title: 'Setup gaps are still open',
+        copy: `Finish: ${setupGaps.slice(0, 3).join(', ')}${setupGaps.length > 3 ? '...' : ''}`,
+        priority: 'do_today',
+        source: 'setup',
+        action: 'profile',
+        section: 'profile'
+      });
+    }
+
+    const weak = n(summary.weak_listings);
+    if (weak > 0) {
+      tasks.push({
+        id: 'weak_listings',
+        title: `${weak} weak listing${weak === 1 ? '' : 's'} need stronger copy or media`,
+        copy: 'Use weak-listing review to tighten titles, pricing signal, and visual quality.',
+        priority: weak >= 8 ? 'do_today' : 'watch',
+        source: 'listing_health',
+        action: 'weak',
+        section: 'tools'
+      });
+    }
+
+    const postsRemaining = n(summary.account_snapshot?.posts_remaining);
+    const queueCount = n(summary.queue_count);
+    if (postsRemaining > 0 && queueCount > 0) {
+      tasks.push({
+        id: 'post_queue',
+        title: `Use remaining capacity: ${postsRemaining} post${postsRemaining === 1 ? '' : 's'} left`,
+        copy: `There ${queueCount === 1 ? 'is' : 'are'} ${queueCount} queued vehicle${queueCount === 1 ? '' : 's'} ready to move now.`,
+        priority: 'do_now',
+        source: 'output',
+        action: 'queue',
+        section: 'extension'
+      });
+    }
+
+    if (n(revenue.refresh_candidates) > 0) {
+      tasks.push({
+        id: 'refresh_candidates',
+        title: `${n(revenue.refresh_candidates)} refresh candidate${n(revenue.refresh_candidates) === 1 ? '' : 's'}`,
+        copy: 'Treat refresh candidates as revenue recovery, not just maintenance.',
+        priority: 'watch',
+        source: 'revenue',
+        action: 'refresh',
+        section: 'tools'
+      });
+    }
+
+    const deduped = new Map();
+    tasks.forEach((task) => {
+      if (!deduped.has(task.id)) deduped.set(task.id, task);
+    });
+
+    const rank = { do_now: 4, do_today: 3, watch: 2, low: 1 };
+    return Array.from(deduped.values()).sort((left, right) => (rank[right.priority] || 0) - (rank[left.priority] || 0));
+  }
+
+  function filterTasks(tasks, mode) {
+    if (mode === 'today') return tasks.filter((task) => ['do_now', 'do_today'].includes(task.priority));
+    if (mode === 'revenue_leaks') return tasks.filter((task) => ['stale_refresh', 'weak_listings', 'refresh_candidates', 'review_queue'].includes(task.id) || task.source === 'revenue');
+    if (mode === 'review') return tasks.filter((task) => task.action === 'review' || task.id === 'review_queue');
+    if (mode === 'setup') return tasks.filter((task) => task.section === 'profile');
+    if (mode === 'queue') return tasks.filter((task) => task.action === 'queue');
+    return tasks;
+  }
+
+  function ensureMount() {
+    const overview = document.getElementById('overview');
+    if (!overview) return null;
+
+    let mount = document.getElementById('salesosMount');
+    if (mount) return mount;
+
+    mount = document.createElement('div');
+    mount.id = 'salesosMount';
+    const commandGrid = overview.querySelector('.command-center-grid');
+    if (commandGrid) {
+      commandGrid.insertAdjacentElement('afterend', mount);
+    } else {
+      overview.prepend(mount);
+    }
+    return mount;
+  }
+
+  function renderSalesOS({ reason = 'manual' } = {}) {
+    if (NS.flags?.disablePhase5) return;
+
+    const mount = ensureMount();
+    if (!mount) return;
+
+    NS.ui?.injectStyleOnce?.('elevate-dashboard-phase5-workflow', CSS);
+
+    const summary = window.dashboardSummary || {};
+    const storedMode = NS.state?.get?.('workflow.mode', 'today') || 'today';
+    const storedRole = NS.state?.get?.('workflow.role', '') || '';
+    const mode = storedMode || 'today';
+    const role = storedRole || inferRole(summary);
+    const tasks = buildWorkflowTasks(summary);
+    const filtered = filterTasks(tasks, mode);
+
+    const access = clean(window.currentNormalizedSession?.subscription?.plan || summary.account_snapshot?.plan || 'Founder Beta');
+    const reviewQueue = n(summary.review_queue_count);
+    const stale = n(summary.stale_listings);
+    const queue = n(summary.queue_count);
+    const weak = n(summary.weak_listings);
+    const revenueAttention = reviewQueue + stale + weak + n(summary.needs_action_count);
+
+    mount.innerHTML = `
+      <div class="salesos-shell">
+        <div class="salesos-bar">
+          <div class="salesos-card">
+            <div class="salesos-eyebrow">Sales OS</div>
+            <div class="salesos-title">Unified Task Queue</div>
+            <div class="salesos-sub">Run the next highest-leverage move from one operator surface instead of hunting across cards.</div>
+            <div class="salesos-chip-row">
+              <span class="salesos-chip">Role: ${role}</span>
+              <span class="salesos-chip">Mode: ${mode.replaceAll('_', ' ')}</span>
+              <span class="salesos-chip">Plan: ${access}</span>
+              <span class="salesos-chip">Reason: ${clean(reason || 'render')}</span>
+            </div>
+          </div>
+          <div class="salesos-card">
+            <div class="salesos-eyebrow">Operating Modes</div>
+            <div class="salesos-controls">
+              <select id="salesosModeSelect" class="salesos-select">
+                <option value="today"${mode === 'today' ? ' selected' : ''}>Today</option>
+                <option value="revenue_leaks"${mode === 'revenue_leaks' ? ' selected' : ''}>Revenue Leaks</option>
+                <option value="review"${mode === 'review' ? ' selected' : ''}>Review Queue</option>
+                <option value="queue"${mode === 'queue' ? ' selected' : ''}>Queue</option>
+                <option value="setup"${mode === 'setup' ? ' selected' : ''}>Setup</option>
+                <option value="all"${mode === 'all' ? ' selected' : ''}>All</option>
+              </select>
+              <select id="salesosRoleSelect" class="salesos-select">
+                <option value="salesperson"${role === 'salesperson' ? ' selected' : ''}>Salesperson View</option>
+                <option value="manager"${role === 'manager' ? ' selected' : ''}>Manager View</option>
+                <option value="hybrid"${role === 'hybrid' ? ' selected' : ''}>Hybrid View</option>
+              </select>
+            </div>
+            <div class="salesos-chip-row">
+              <span class="salesos-chip">Review: ${reviewQueue}</span>
+              <span class="salesos-chip">Stale: ${stale}</span>
+              <span class="salesos-chip">Queue: ${queue}</span>
+              <span class="salesos-chip">Revenue Attention: ${revenueAttention}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="salesos-grid">
+          <div class="salesos-card">
+            <div class="salesos-eyebrow">Task Queue</div>
+            <div class="salesos-queue" id="salesosTaskQueue">
+              ${filtered.length ? filtered.map((task) => {
+                const priority = formatPriority(task.priority);
+                return `
+                  <div class="salesos-task">
+                    <div class="salesos-task-head">
+                      <div>
+                        <div class="salesos-task-title">${task.title}</div>
+                        <div class="salesos-task-meta">${task.source.replaceAll('_', ' ')} • section: ${task.section}</div>
+                      </div>
+                      <span class="salesos-priority ${priority.key}">${priority.label}</span>
+                    </div>
+                    <div class="salesos-task-copy">${task.copy}</div>
+                    <div class="salesos-task-actions">
+                      <button class="salesos-btn primary" type="button" data-salesos-open="${task.section}">Open ${task.section}</button>
+                      <button class="salesos-btn" type="button" data-salesos-focus="${task.action || task.section}">Focus</button>
+                    </div>
+                  </div>
+                `;
+              }).join('') : '<div class="salesos-empty">No tasks in this mode yet.</div>'}
+            </div>
+          </div>
+
+          <div class="salesos-card">
+            <div class="salesos-eyebrow">Role Surface</div>
+            <div class="salesos-side-list">
+              <div class="salesos-side-item"><strong>Salesperson</strong><br><span class="salesos-sub">Execution, queue movement, listing review, and output speed.</span></div>
+              <div class="salesos-side-item"><strong>Manager</strong><br><span class="salesos-sub">Review pressure, team visibility, revenue leaks, and inventory health.</span></div>
+              <div class="salesos-side-item"><strong>Hybrid</strong><br><span class="salesos-sub">Sales workflow plus affiliate / growth activity on the same surface.</span></div>
+              <div class="salesos-side-item"><strong>Why this matters</strong><br><span class="salesos-sub">This layer turns the dashboard into a task-driven operator surface instead of a static card wall.</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    const modeSelect = document.getElementById('salesosModeSelect');
+    if (modeSelect) {
+      modeSelect.addEventListener('change', () => {
+        NS.state?.set?.('workflow.mode', modeSelect.value);
+        renderSalesOS({ reason: 'mode_change' });
+      }, { once: true });
+    }
+
+    const roleSelect = document.getElementById('salesosRoleSelect');
+    if (roleSelect) {
+      roleSelect.addEventListener('change', () => {
+        NS.state?.set?.('workflow.role', roleSelect.value);
+        renderSalesOS({ reason: 'role_change' });
+      }, { once: true });
+    }
+
+    mount.querySelectorAll('[data-salesos-open]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const section = button.getAttribute('data-salesos-open') || 'overview';
+        if (typeof window.showSection === 'function') {
+          window.showSection(section);
+        }
+      }, { once: true });
+    });
+
+    mount.querySelectorAll('[data-salesos-focus]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const focusLabel = clean(button.getAttribute('data-salesos-focus') || 'task');
+        const status = document.getElementById('bootStatus');
+        if (status) status.textContent = `Sales OS focus: ${focusLabel}`;
+      }, { once: true });
+    });
+  }
+
+  NS.phase5workflow = { renderSalesOS, buildWorkflowTasks };
+  NS.modules = NS.modules || {};
+  NS.modules.phase5workflow = true;
+})();

--- a/stabilization/bundle-1/dashboard.js
+++ b/stabilization/bundle-1/dashboard.js
@@ -1,0 +1,98 @@
+(() => {
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  if (NS.loaderInitialized) return;
+  NS.loaderInitialized = true;
+
+  function safeLocalStorageGet(key) {
+    try {
+      return window.localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const hasParam = (key) => params.get(key) === '1';
+  const hasStoredFlag = (key) => safeLocalStorageGet(key) === '1';
+
+  const flags = {
+    safeMode: hasParam('safe') || hasStoredFlag('ea_dashboard_safe_mode'),
+    disablePhase5: hasParam('disablePhase5') || hasStoredFlag('ea_dashboard_disable_phase5'),
+    disableOverviewHierarchy: hasParam('disableOverviewHierarchy') || hasStoredFlag('ea_dashboard_disable_overview_hierarchy'),
+    debugBoot: hasParam('debugBoot') || hasStoredFlag('ea_dashboard_debug_boot')
+  };
+
+  if (flags.safeMode) {
+    flags.disablePhase5 = true;
+  }
+
+  NS.flags = { ...(NS.flags || {}), ...flags };
+  NS.version = 'dashboard-stabilization-bundle-1';
+  window.__EA_DASHBOARD_FLAGS__ = NS.flags;
+
+  const MODULES = [
+    '/dashboard-state.js?v=20260406-stab1',
+    '/dashboard-ui.js?v=20260406-stab1',
+    '/dashboard-api.js?v=20260406-stab1',
+    '/dashboard-overview.js?v=20260406-stab1',
+    '/dashboard-listings.js?v=20260406-stab1',
+    '/dashboard-profile.js?v=20260406-stab1',
+    '/dashboard-tools.js?v=20260406-stab1',
+    '/dashboard-analytics.js?v=20260406-stab1',
+    '/dashboard-affiliate.js?v=20260406-stab1',
+    '/dashboard-billing.js?v=20260406-stab1',
+    '/dashboard-legacy.js?v=20260406-stab1',
+    '/dashboard-phase4-boot.js?v=20260406-stab1',
+    '/dashboard-bootstrap.js?v=20260406-stab1'
+  ];
+
+  function setBootStatus(message) {
+    const node = document.getElementById('bootStatus');
+    if (node) node.textContent = message || '';
+  }
+
+  function scriptAlreadyPresent(src) {
+    const base = src.split('?')[0];
+    return Array.from(document.scripts).some((script) => {
+      try {
+        return script.src && new URL(script.src, window.location.origin).pathname === base;
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  function loadModule(src) {
+    return new Promise((resolve, reject) => {
+      if (scriptAlreadyPresent(src)) {
+        resolve();
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = false;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error(`Failed to load ${src}`));
+      document.head.appendChild(script);
+    });
+  }
+
+  async function loadSequentially(index = 0) {
+    if (index >= MODULES.length) return;
+    const src = MODULES[index];
+    await loadModule(src);
+    await loadSequentially(index + 1);
+  }
+
+  loadSequentially()
+    .then(() => {
+      if (NS.flags.safeMode) {
+        setBootStatus('Safe mode active. Phase 5 workflow is disabled.');
+      }
+    })
+    .catch((error) => {
+      console.error('[Elevate Dashboard] loader failure:', error);
+      setBootStatus(`Loader failed: ${error.message || 'Unknown error'}`);
+    });
+})();


### PR DESCRIPTION
## Summary

This PR adds a **stabilization bundle** for the website-side dashboard so the current freeze issue can be applied in one grouped pass.

It does **not** overwrite the live root files automatically. Instead, it adds a clean replacement bundle under:

- `stabilization/bundle-1/`

This keeps the current branch safe while giving you a ready implementation package to copy into the live root files.

## Included phases

### Phase 1 — P0 stabilization
- isolates the likely phase-5/state render loop path
- removes the need for synthetic bootstrap recursion
- adds a safe fallback route

### Phase 2 — boot hardening
- adds cleaner boot telemetry behavior
- adds `?safe=1` recovery mode
- keeps core dashboard availability even when phase 5 is disabled

### Phase 3 — phase-4 orchestration cleanup
- only rerenders Sales OS on targeted state changes
- keeps overview hierarchy and phase-5 behavior separated

### Phase 4 — phase-5 workflow isolation
- rewrites Sales OS as a rendering layer instead of a render-triggering state writer
- preserves mode/role selectors without writing state during task build/render

## Files added

- `stabilization/bundle-1/README.md`
- `stabilization/bundle-1/dashboard.js`
- `stabilization/bundle-1/dashboard-bootstrap.js`
- `stabilization/bundle-1/dashboard-phase4-boot.js`
- `stabilization/bundle-1/dashboard-phase5-workflow.js`

## Apply steps

Copy each bundle file over the matching root file:

- `stabilization/bundle-1/dashboard.js` -> `/dashboard.js`
- `stabilization/bundle-1/dashboard-bootstrap.js` -> `/dashboard-bootstrap.js`
- `stabilization/bundle-1/dashboard-phase4-boot.js` -> `/dashboard-phase4-boot.js`
- `stabilization/bundle-1/dashboard-phase5-workflow.js` -> `/dashboard-phase5-workflow.js`

## Expected outcome

After applying the replacements:
- dashboard should stop hanging from the current phase-5 render loop path
- boot telemetry should remain visible without redispatching `DOMContentLoaded`
- `/dashboard.html?safe=1` should provide a recovery path
- Sales OS should render as a controlled layer instead of feeding back into its own render cycle

## Suggested test order

1. open `/dashboard.html?safe=1`
2. confirm the core dashboard loads without freezing
3. open `/dashboard.html`
4. confirm Sales OS renders under overview
5. switch mode and role selectors
6. confirm no browser freeze / no repeated loading loop
