### PR TITLE
Dashboard stabilization bundle 2: DOM-ready bridge and legacy boot recovery

### DIFF
--- a/stabilization/bundle-2/README.md
+++ b/stabilization/bundle-2/README.md
@@ -1,0 +1,62 @@
+# Dashboard Stabilization Bundle 2
+
+This bundle targets the deeper root cause behind the current blank-loading dashboard state.
+
+## Root cause this bundle addresses
+
+The current loader dynamically injects the dashboard module chain.
+That means `dashboard-legacy.js` can be loaded **after** the page has already passed `DOMContentLoaded`.
+
+When that happens, the legacy dashboard boot listener never runs.
+The result is exactly what the current screenshots show:
+
+- sidebar loads
+- static shell renders
+- `Loading dashboard...` stays forever
+- no real hydration starts
+
+## What this bundle changes
+
+### 1. DOM-ready bridge
+Adds a small bridge so scripts that attach `DOMContentLoaded` late still execute their boot callback immediately.
+
+### 2. Loader update
+Loads the DOM-ready bridge before `dashboard-legacy.js`.
+
+### 3. Bootstrap cleanup
+Removes synthetic `DOMContentLoaded` redispatch behavior.
+Bootstrap should observe and report, not re-fire browser lifecycle events.
+
+### 4. Phase-4 rerender hardening
+Stops the broad `state:set -> rerender everything` behavior and narrows rerenders to targeted workflow keys.
+
+### 5. Phase-5 isolation
+Uses a render-only Sales OS layer that does not write back into state during task-build render paths.
+
+## Files in this bundle
+
+Copy these files into the repo root exactly as mapped below:
+
+- `stabilization/bundle-2/dashboard.js` -> `/dashboard.js`
+- `stabilization/bundle-2/dashboard-dom-ready-bridge.js` -> `/dashboard-dom-ready-bridge.js`
+- `stabilization/bundle-2/dashboard-bootstrap.js` -> `/dashboard-bootstrap.js`
+- `stabilization/bundle-2/dashboard-phase4-boot.js` -> `/dashboard-phase4-boot.js`
+- `stabilization/bundle-2/dashboard-phase5-workflow.js` -> `/dashboard-phase5-workflow.js`
+
+## Expected result
+
+After applying Bundle 2:
+
+- legacy dashboard boot should run even when loaded after DOM ready
+- the dashboard should begin real hydration instead of sitting on the static shell
+- bootstrap should stop forcing synthetic page lifecycle events
+- Sales OS should remain isolated from recursive state writes
+
+## Test order
+
+1. Open `/dashboard.html`
+2. Confirm boot telemetry appears
+3. Confirm profile/session/listing requests start
+4. Confirm the user card and page body stop saying `Loading...`
+5. Confirm Sales OS renders without freezing the page
+6. Open `/dashboard.html?safe=1` and confirm safe mode still provides recovery

--- a/stabilization/bundle-2/dashboard-bootstrap.js
+++ b/stabilization/bundle-2/dashboard-bootstrap.js
@@ -1,0 +1,233 @@
+(() => {
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  if (NS.modules?.bootstrap) return;
+
+  const RETRY_TIMEOUT_MS = 15000;
+  const POLL_MS = 500;
+
+  const CSS = `
+    .ea-boot-panel {
+      margin: 12px 0 18px;
+      padding: 14px 16px;
+      border: 1px solid rgba(212,175,55,0.14);
+      border-radius: 14px;
+      background: rgba(255,255,255,0.02);
+      display: grid;
+      gap: 8px;
+    }
+    .ea-boot-panel-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .ea-boot-eyebrow {
+      color: #d4af37;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    .ea-boot-badge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      padding: 0 10px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 700;
+      border: 1px solid rgba(255,255,255,0.08);
+      background: #171717;
+      color: #f4f4f4;
+    }
+    .ea-boot-badge.running { color: #f3ddb0; border-color: rgba(212,175,55,0.18); }
+    .ea-boot-badge.ready { color: #9de8a8; border-color: rgba(157,232,168,0.22); }
+    .ea-boot-badge.error { color: #ffb4b4; border-color: rgba(255,180,180,0.2); }
+    .ea-boot-title { font-size: 14px; font-weight: 700; }
+    .ea-boot-detail { font-size: 13px; color: #b8b8b8; line-height: 1.5; }
+    .ea-boot-stage-list { display: grid; gap: 6px; }
+    .ea-boot-stage-item { font-size: 12px; color: #d6d6d6; }
+    .ea-boot-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+    .ea-boot-actions button {
+      appearance: none;
+      border: 1px solid rgba(255,255,255,0.08);
+      background: #1a1a1a;
+      color: #f2f2f2;
+      border-radius: 10px;
+      padding: 10px 12px;
+      cursor: pointer;
+      font-size: 12px;
+    }
+  `;
+
+  function qs(selector, root = document) {
+    return root.querySelector(selector);
+  }
+
+  function clean(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function injectStyles() {
+    if (document.getElementById('ea-boot-panel-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'ea-boot-panel-styles';
+    style.textContent = CSS;
+    document.head.appendChild(style);
+  }
+
+  function ensurePanel() {
+    injectStyles();
+    let panel = document.getElementById('eaBootPanel');
+    if (panel) return panel;
+
+    panel = document.createElement('div');
+    panel.id = 'eaBootPanel';
+    panel.className = 'ea-boot-panel';
+    panel.innerHTML = `
+      <div class="ea-boot-panel-head">
+        <div>
+          <div class="ea-boot-eyebrow">Boot Telemetry</div>
+          <div id="eaBootTitle" class="ea-boot-title">Starting dashboard bootstrap...</div>
+        </div>
+        <div id="eaBootBadge" class="ea-boot-badge running">Running</div>
+      </div>
+      <div id="eaBootDetail" class="ea-boot-detail">Preparing telemetry and startup controller.</div>
+      <div id="eaBootStages" class="ea-boot-stage-list"></div>
+      <div class="ea-boot-actions">
+        <button id="eaBootRetryBtn" type="button">Retry bootstrap</button>
+        <button id="eaBootReloadBtn" type="button">Reload page</button>
+      </div>
+    `;
+
+    const header = qs('.main-header') || document.body;
+    header.insertAdjacentElement('afterend', panel);
+
+    document.getElementById('eaBootRetryBtn')?.addEventListener('click', () => {
+      if (typeof window.__ELEVATE_DASHBOARD_LEGACY_BOOT__ === 'function') {
+        try {
+          window.__ELEVATE_DASHBOARD_LEGACY_BOOT__({ reason: 'manual_retry' });
+        } catch (error) {
+          console.warn('[Elevate Dashboard] manual retry warning:', error);
+        }
+      }
+    });
+
+    document.getElementById('eaBootReloadBtn')?.addEventListener('click', () => window.location.reload());
+    return panel;
+  }
+
+  function renderStages(stages = []) {
+    const wrap = document.getElementById('eaBootStages');
+    if (!wrap) return;
+    wrap.innerHTML = stages.slice(-6).map((item) => `<div class="ea-boot-stage-item">• ${item}</div>`).join('');
+  }
+
+  function updatePanel(status, title, detail) {
+    ensurePanel();
+    const badge = document.getElementById('eaBootBadge');
+    const titleEl = document.getElementById('eaBootTitle');
+    const detailEl = document.getElementById('eaBootDetail');
+    if (badge) {
+      badge.className = `ea-boot-badge ${status}`;
+      badge.textContent = status === 'ready' ? 'Ready' : status === 'error' ? 'Error' : 'Running';
+    }
+    if (titleEl) titleEl.textContent = title || 'Boot status';
+    if (detailEl) detailEl.textContent = detail || '';
+    const bootStatus = document.getElementById('bootStatus');
+    if (bootStatus) bootStatus.textContent = detail || title || '';
+  }
+
+  function pushStage(label, detail = '') {
+    NS.bootstrapState = NS.bootstrapState || { stages: [] };
+    const line = detail ? `${label}: ${detail}` : label;
+    NS.bootstrapState.stages.push(line);
+    renderStages(NS.bootstrapState.stages);
+    updatePanel('running', label, detail);
+  }
+
+  function getIndicators() {
+    const userEmailText = clean(qs('.user-email')?.textContent || '');
+    const welcomeText = clean(document.getElementById('welcomeText')?.textContent || '');
+    return {
+      shellLoading: /loading/i.test(userEmailText) || /loading dashboard/i.test(welcomeText),
+      hasUser: Boolean(window.currentUser?.id) || (userEmailText && !/loading/i.test(userEmailText)),
+      hasSession: Boolean(window.currentNormalizedSession?.subscription || window.currentAccountData),
+      hasSummary: Boolean(window.dashboardSummary && typeof window.dashboardSummary === 'object'),
+      hasListings: Array.isArray(window.dashboardListings) && window.dashboardListings.length > 0
+    };
+  }
+
+  function maybeRunLegacyBoot() {
+    if (typeof window.__ELEVATE_DASHBOARD_LEGACY_BOOT__ !== 'function') return;
+    if (window.__ELEVATE_DASHBOARD_LEGACY_BOOT_RAN__) return;
+    try {
+      window.__ELEVATE_DASHBOARD_LEGACY_BOOT__({ reason: 'bootstrap_watch' });
+    } catch (error) {
+      console.warn('[Elevate Dashboard] legacy boot trigger warning:', error);
+    }
+  }
+
+  function maybeRenderPhase5() {
+    try {
+      NS.phase5workflow?.renderSalesOS?.({ reason: 'bootstrap_watch' });
+    } catch (error) {
+      console.warn('[Elevate Dashboard] Phase 5 render warning:', error);
+    }
+  }
+
+  function startWatch() {
+    ensurePanel();
+    pushStage('Bootstrap', 'Watching shell hydration and dashboard readiness.');
+
+    const startedAt = Date.now();
+    const tick = () => {
+      const indicators = getIndicators();
+      maybeRunLegacyBoot();
+
+      if (indicators.hasUser && !indicators.hasSummary) {
+        updatePanel('running', 'User resolved', 'Waiting for dashboard summary and workspace hydration.');
+      }
+
+      if (indicators.hasSummary && !indicators.hasSession) {
+        updatePanel('running', 'Summary resolved', 'Waiting for normalized session and section render pass.');
+      }
+
+      if (indicators.hasSummary && indicators.hasSession) {
+        maybeRenderPhase5();
+      }
+
+      if (!indicators.shellLoading && indicators.hasUser && indicators.hasSummary && indicators.hasSession) {
+        pushStage('Ready', 'Core dashboard hydration completed.');
+        updatePanel('ready', 'Dashboard hydrated', indicators.hasListings ? 'Workspace, summary, and listings are available.' : 'Workspace and summary are available. Listings may still be hydrating.');
+        clearInterval(intervalId);
+        return;
+      }
+
+      if (Date.now() - startedAt > RETRY_TIMEOUT_MS) {
+        updatePanel('error', 'Bootstrap stalled', 'Shell is still partially loaded. Use Retry bootstrap or reload.');
+        clearInterval(intervalId);
+      }
+    };
+
+    const intervalId = setInterval(tick, POLL_MS);
+    tick();
+  }
+
+  function boot() {
+    if (NS.bootstrapState?.started) return;
+    NS.bootstrapState = NS.bootstrapState || {};
+    NS.bootstrapState.started = true;
+    startWatch();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+
+  NS.modules = NS.modules || {};
+  NS.modules.bootstrap = true;
+})();

--- a/stabilization/bundle-2/dashboard-dom-ready-bridge.js
+++ b/stabilization/bundle-2/dashboard-dom-ready-bridge.js
@@ -1,0 +1,38 @@
+(() => {
+  if (window.__EA_DASHBOARD_DOM_READY_BRIDGE__) return;
+  window.__EA_DASHBOARD_DOM_READY_BRIDGE__ = true;
+
+  const originalAddEventListener = document.addEventListener.bind(document);
+  const originalRemoveEventListener = document.removeEventListener.bind(document);
+  const lateDomReadyMap = new WeakMap();
+
+  function isDomReady() {
+    return document.readyState === 'interactive' || document.readyState === 'complete';
+  }
+
+  document.addEventListener = function patchedAddEventListener(type, listener, options) {
+    if (type === 'DOMContentLoaded' && typeof listener === 'function' && isDomReady()) {
+      const once = typeof options === 'object' && options && options.once === true;
+      const wrapped = () => {
+        try {
+          listener.call(document, new Event('DOMContentLoaded'));
+        } catch (error) {
+          console.error('[Elevate Dashboard] late DOMContentLoaded bridge error:', error);
+        }
+      };
+      lateDomReadyMap.set(listener, wrapped);
+      queueMicrotask(wrapped);
+      if (!once) return;
+      return;
+    }
+    return originalAddEventListener(type, listener, options);
+  };
+
+  document.removeEventListener = function patchedRemoveEventListener(type, listener, options) {
+    if (type === 'DOMContentLoaded' && lateDomReadyMap.has(listener)) {
+      lateDomReadyMap.delete(listener);
+      return;
+    }
+    return originalRemoveEventListener(type, listener, options);
+  };
+})();

--- a/stabilization/bundle-2/dashboard-phase4-boot.js
+++ b/stabilization/bundle-2/dashboard-phase4-boot.js
@@ -1,0 +1,91 @@
+(() => {
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  if (NS.modules?.phase4boot) return;
+
+  let phase5ScriptPromise = null;
+  let renderTimer = null;
+  let renderInFlight = false;
+
+  function shouldRenderForPath(path = '') {
+    const normalized = String(path || '');
+    return [
+      'booted',
+      'workflow.mode',
+      'workflow.role',
+      'summary',
+      'listings',
+      'filteredListings',
+      'ui.activeSection'
+    ].includes(normalized);
+  }
+
+  function loadPhase5Workflow() {
+    if (phase5ScriptPromise) return phase5ScriptPromise;
+    const src = '/dashboard-phase5-workflow.js?v=20260407b2';
+    const existing = Array.from(document.scripts).find((script) => script.src && script.src.includes('/dashboard-phase5-workflow.js'));
+    if (existing) {
+      phase5ScriptPromise = Promise.resolve();
+      return phase5ScriptPromise;
+    }
+
+    phase5ScriptPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = false;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error(`Failed to load ${src}`));
+      document.head.appendChild(script);
+    });
+    return phase5ScriptPromise;
+  }
+
+  function queuePhase5Render(reason = 'boot') {
+    if (renderInFlight) return;
+    clearTimeout(renderTimer);
+    renderTimer = window.setTimeout(() => {
+      renderInFlight = true;
+      try {
+        NS.phase5workflow?.renderSalesOS?.({ reason });
+      } catch (error) {
+        console.warn('[Elevate Dashboard] Phase 5 render warning:', error);
+      } finally {
+        renderInFlight = false;
+      }
+    }, 60);
+  }
+
+  async function boot() {
+    try {
+      NS.overview?.applyOverviewHierarchy?.();
+      await loadPhase5Workflow().catch((error) => {
+        console.warn('[Elevate Dashboard] Phase 5 workflow load warning:', error);
+      });
+      queuePhase5Render('phase4_boot');
+
+      if (NS.events && !NS.__phase5StateListenerBound) {
+        NS.__phase5StateListenerBound = true;
+        NS.events.addEventListener('state:set', (event) => {
+          const path = event?.detail?.path || '';
+          if (shouldRenderForPath(path)) {
+            queuePhase5Render(path);
+          }
+        });
+      }
+
+      if (NS.state && !NS.state.get?.('booted')) {
+        NS.state.set('booted', true);
+      }
+    } catch (error) {
+      console.warn('[Elevate Dashboard] Phase 4 boot warning:', error);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+
+  NS.modules = NS.modules || {};
+  NS.modules.phase4boot = true;
+})();

--- a/stabilization/bundle-2/dashboard-phase5-workflow.js
+++ b/stabilization/bundle-2/dashboard-phase5-workflow.js
@@ -1,0 +1,323 @@
+(() => {
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  if (NS.modules?.phase5workflow) return;
+
+  const CSS = `
+    .salesos-shell { display:grid; gap:16px; margin-bottom:16px; }
+    .salesos-bar { display:grid; grid-template-columns: 1.15fr 1fr; gap:16px; }
+    .salesos-card { background:#121212; border:1px solid rgba(212,175,55,0.12); border-radius:18px; padding:18px; box-shadow:0 10px 30px rgba(0,0,0,0.28); }
+    .salesos-eyebrow { color:#d4af37; font-size:12px; font-weight:700; letter-spacing:1.3px; text-transform:uppercase; margin-bottom:8px; }
+    .salesos-title { font-size:24px; font-weight:700; line-height:1.1; margin-bottom:8px; }
+    .salesos-sub { color:#b8b8b8; font-size:14px; line-height:1.55; }
+    .salesos-chip-row { display:flex; gap:8px; flex-wrap:wrap; margin-top:14px; }
+    .salesos-chip { display:inline-flex; align-items:center; min-height:34px; padding:0 12px; border-radius:999px; background:rgba(212,175,55,0.10); border:1px solid rgba(212,175,55,0.16); color:#f3ddb0; font-size:12px; font-weight:700; }
+    .salesos-controls { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
+    .salesos-select { background:#171717; color:#f5f5f5; border:1px solid rgba(255,255,255,0.08); border-radius:12px; padding:12px 14px; font-size:14px; min-width:160px; }
+    .salesos-grid { display:grid; grid-template-columns: 1.35fr 0.95fr; gap:16px; }
+    .salesos-queue { display:grid; gap:12px; }
+    .salesos-task { background:#161616; border:1px solid rgba(255,255,255,0.06); border-radius:16px; padding:14px; display:grid; gap:10px; }
+    .salesos-task-head { display:flex; justify-content:space-between; align-items:flex-start; gap:12px; }
+    .salesos-task-title { font-size:15px; font-weight:700; line-height:1.35; }
+    .salesos-task-meta { color:#a7a7a7; font-size:12px; line-height:1.4; }
+    .salesos-priority { display:inline-flex; align-items:center; padding:6px 10px; border-radius:999px; font-size:11px; font-weight:700; letter-spacing:0.06em; text-transform:uppercase; border:1px solid rgba(255,255,255,0.08); }
+    .salesos-priority.do_now { background:rgba(212,175,55,0.14); color:#f3ddb0; border-color:rgba(212,175,55,0.2); }
+    .salesos-priority.do_today { background:rgba(255,255,255,0.06); color:#ececec; }
+    .salesos-priority.watch { background:rgba(56,122,255,0.12); color:#cfe0ff; border-color:rgba(56,122,255,0.18); }
+    .salesos-priority.low { background:rgba(120,120,120,0.14); color:#d7d7d7; }
+    .salesos-task-copy { color:#ececec; font-size:13px; line-height:1.55; }
+    .salesos-task-actions { display:flex; gap:8px; flex-wrap:wrap; }
+    .salesos-btn { appearance:none; border:1px solid rgba(255,255,255,0.08); background:#1a1a1a; color:#f2f2f2; border-radius:12px; padding:10px 12px; cursor:pointer; font-size:13px; }
+    .salesos-btn.primary { background:#d4af37; color:#0b0b0b; border:none; font-weight:700; }
+    .salesos-side-list { display:grid; gap:10px; }
+    .salesos-side-item { background:#171717; border:1px solid rgba(255,255,255,0.06); border-radius:14px; padding:12px; }
+    .salesos-empty { padding:18px; border-radius:16px; border:1px dashed rgba(212,175,55,0.18); color:#a9a9a9; background:#111; text-align:center; }
+    @media (max-width: 1180px) {
+      .salesos-bar, .salesos-grid { grid-template-columns: 1fr; }
+    }
+  `;
+
+  function n(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : 0;
+  }
+
+  function clean(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function formatPriority(priority) {
+    const normalized = clean(priority).toLowerCase();
+    if (normalized === 'do_now') return { key: 'do_now', label: 'Do Now' };
+    if (normalized === 'do_today') return { key: 'do_today', label: 'Do Today' };
+    if (normalized === 'watch') return { key: 'watch', label: 'Watch' };
+    return { key: 'low', label: 'Low' };
+  }
+
+  function inferRole(summary = {}) {
+    if (summary.manager_access) return 'manager';
+    if ((summary.affiliate || {}).referral_code) return 'hybrid';
+    return 'salesperson';
+  }
+
+  function buildWorkflowTasks(summary = {}) {
+    const tasks = [];
+    const actionDetails = summary.action_center_details || {};
+    const revenue = summary.revenue_intelligence || {};
+    const setup = summary.setup_status || {};
+
+    const todayItems = Array.isArray(actionDetails.today) ? actionDetails.today : [];
+    todayItems.forEach((item, index) => {
+      tasks.push({
+        id: clean(item.id || `today_${index}`),
+        title: clean(item.title || item.label || 'Priority task'),
+        copy: clean(item.copy || item.description || item.reason || 'Review this task.'),
+        priority: 'do_now',
+        source: 'action_center',
+        action: clean(item.action || ''),
+        section: 'overview'
+      });
+    });
+
+    const stale = n(summary.stale_listings);
+    if (stale > 0) {
+      tasks.push({
+        id: 'stale_refresh',
+        title: `${stale} stale listing${stale === 1 ? '' : 's'} need refresh`,
+        copy: 'Move stale inventory into the first recovery pass so visibility and repost flow do not lag.',
+        priority: stale >= 10 ? 'do_now' : 'do_today',
+        source: 'listing_health',
+        action: 'stale',
+        section: 'overview'
+      });
+    }
+
+    const reviewQueue = n(summary.review_queue_count);
+    if (reviewQueue > 0) {
+      tasks.push({
+        id: 'review_queue',
+        title: `${reviewQueue} listing${reviewQueue === 1 ? '' : 's'} waiting for review`,
+        copy: 'Clear review friction first so the queue does not slow the operating loop.',
+        priority: reviewQueue >= 10 ? 'do_now' : 'do_today',
+        source: 'review_queue',
+        action: 'review',
+        section: 'overview'
+      });
+    }
+
+    const setupGaps = Array.isArray(setup.setup_gaps) ? setup.setup_gaps.filter(Boolean) : [];
+    if (setupGaps.length) {
+      tasks.push({
+        id: 'setup_gap',
+        title: 'Setup gaps are still open',
+        copy: `Finish: ${setupGaps.slice(0, 3).join(', ')}${setupGaps.length > 3 ? '...' : ''}`,
+        priority: 'do_today',
+        source: 'setup',
+        action: 'profile',
+        section: 'profile'
+      });
+    }
+
+    const weak = n(summary.weak_listings);
+    if (weak > 0) {
+      tasks.push({
+        id: 'weak_listings',
+        title: `${weak} weak listing${weak === 1 ? '' : 's'} need stronger copy or media`,
+        copy: 'Use weak-listing review to tighten titles, pricing signal, and visual quality.',
+        priority: weak >= 8 ? 'do_today' : 'watch',
+        source: 'listing_health',
+        action: 'weak',
+        section: 'tools'
+      });
+    }
+
+    const postsRemaining = n(summary.account_snapshot?.posts_remaining);
+    const queueCount = n(summary.queue_count);
+    if (postsRemaining > 0 && queueCount > 0) {
+      tasks.push({
+        id: 'post_queue',
+        title: `Use remaining capacity: ${postsRemaining} post${postsRemaining === 1 ? '' : 's'} left`,
+        copy: `There ${queueCount === 1 ? 'is' : 'are'} ${queueCount} queued vehicle${queueCount === 1 ? '' : 's'} ready to move now.`,
+        priority: 'do_now',
+        source: 'output',
+        action: 'queue',
+        section: 'extension'
+      });
+    }
+
+    if (n(revenue.refresh_candidates) > 0) {
+      tasks.push({
+        id: 'refresh_candidates',
+        title: `${n(revenue.refresh_candidates)} refresh candidate${n(revenue.refresh_candidates) === 1 ? '' : 's'}`,
+        copy: 'Treat refresh candidates as revenue recovery, not just maintenance.',
+        priority: 'watch',
+        source: 'revenue',
+        action: 'refresh',
+        section: 'tools'
+      });
+    }
+
+    const deduped = new Map();
+    tasks.forEach((task) => {
+      if (!deduped.has(task.id)) deduped.set(task.id, task);
+    });
+
+    const rank = { do_now: 4, do_today: 3, watch: 2, low: 1 };
+    return Array.from(deduped.values()).sort((left, right) => (rank[right.priority] || 0) - (rank[left.priority] || 0));
+  }
+
+  function filterTasks(tasks, mode) {
+    if (mode === 'today') return tasks.filter((task) => ['do_now', 'do_today'].includes(task.priority));
+    if (mode === 'revenue_leaks') return tasks.filter((task) => ['stale_refresh', 'weak_listings', 'refresh_candidates', 'review_queue'].includes(task.id) || task.source === 'revenue');
+    if (mode === 'review') return tasks.filter((task) => task.action === 'review' || task.id === 'review_queue');
+    if (mode === 'setup') return tasks.filter((task) => task.section === 'profile');
+    if (mode === 'queue') return tasks.filter((task) => task.action === 'queue');
+    return tasks;
+  }
+
+  function ensureMount() {
+    const overview = document.getElementById('overview');
+    if (!overview) return null;
+
+    let mount = document.getElementById('salesosMount');
+    if (mount) return mount;
+
+    mount = document.createElement('div');
+    mount.id = 'salesosMount';
+    const commandGrid = overview.querySelector('.command-center-grid');
+    if (commandGrid) commandGrid.insertAdjacentElement('afterend', mount);
+    else overview.prepend(mount);
+    return mount;
+  }
+
+  function renderSalesOS({ reason = 'manual' } = {}) {
+    const mount = ensureMount();
+    if (!mount) return;
+
+    NS.ui?.injectStyleOnce?.('elevate-dashboard-phase5-workflow', CSS);
+
+    const summary = window.dashboardSummary || {};
+    const mode = NS.state?.get?.('workflow.mode', 'today') || 'today';
+    const role = NS.state?.get?.('workflow.role', '') || inferRole(summary);
+    const tasks = buildWorkflowTasks(summary);
+    const filtered = filterTasks(tasks, mode);
+
+    const access = clean(window.currentNormalizedSession?.subscription?.plan || summary.account_snapshot?.plan || 'Founder Beta');
+    const reviewQueue = n(summary.review_queue_count);
+    const stale = n(summary.stale_listings);
+    const queue = n(summary.queue_count);
+    const weak = n(summary.weak_listings);
+    const revenueAttention = reviewQueue + stale + weak + n(summary.needs_action_count);
+
+    mount.innerHTML = `
+      <div class="salesos-shell">
+        <div class="salesos-bar">
+          <div class="salesos-card">
+            <div class="salesos-eyebrow">Sales OS</div>
+            <div class="salesos-title">Unified Task Queue</div>
+            <div class="salesos-sub">Run the next highest-leverage move from one operator surface instead of hunting across cards.</div>
+            <div class="salesos-chip-row">
+              <span class="salesos-chip">Role: ${role}</span>
+              <span class="salesos-chip">Mode: ${mode.replaceAll('_', ' ')}</span>
+              <span class="salesos-chip">Plan: ${access}</span>
+              <span class="salesos-chip">Reason: ${clean(reason || 'render')}</span>
+            </div>
+          </div>
+          <div class="salesos-card">
+            <div class="salesos-eyebrow">Operating Modes</div>
+            <div class="salesos-controls">
+              <select id="salesosModeSelect" class="salesos-select">
+                <option value="today"${mode === 'today' ? ' selected' : ''}>Today</option>
+                <option value="revenue_leaks"${mode === 'revenue_leaks' ? ' selected' : ''}>Revenue Leaks</option>
+                <option value="review"${mode === 'review' ? ' selected' : ''}>Review Queue</option>
+                <option value="queue"${mode === 'queue' ? ' selected' : ''}>Queue</option>
+                <option value="setup"${mode === 'setup' ? ' selected' : ''}>Setup</option>
+                <option value="all"${mode === 'all' ? ' selected' : ''}>All</option>
+              </select>
+              <select id="salesosRoleSelect" class="salesos-select">
+                <option value="salesperson"${role === 'salesperson' ? ' selected' : ''}>Salesperson View</option>
+                <option value="manager"${role === 'manager' ? ' selected' : ''}>Manager View</option>
+                <option value="hybrid"${role === 'hybrid' ? ' selected' : ''}>Hybrid View</option>
+              </select>
+            </div>
+            <div class="salesos-chip-row">
+              <span class="salesos-chip">Review: ${reviewQueue}</span>
+              <span class="salesos-chip">Stale: ${stale}</span>
+              <span class="salesos-chip">Queue: ${queue}</span>
+              <span class="salesos-chip">Revenue Attention: ${revenueAttention}</span>
+            </div>
+          </div>
+        </div>
+        <div class="salesos-grid">
+          <div class="salesos-card">
+            <div class="salesos-eyebrow">Task Queue</div>
+            <div class="salesos-queue" id="salesosTaskQueue">
+              ${filtered.length ? filtered.map((task) => {
+                const priority = formatPriority(task.priority);
+                return `
+                  <div class="salesos-task">
+                    <div class="salesos-task-head">
+                      <div>
+                        <div class="salesos-task-title">${task.title}</div>
+                        <div class="salesos-task-meta">${task.source.replaceAll('_', ' ')} • section: ${task.section}</div>
+                      </div>
+                      <span class="salesos-priority ${priority.key}">${priority.label}</span>
+                    </div>
+                    <div class="salesos-task-copy">${task.copy}</div>
+                    <div class="salesos-task-actions">
+                      <button class="salesos-btn primary" type="button" data-salesos-open="${task.section}">Open ${task.section}</button>
+                      <button class="salesos-btn" type="button" data-salesos-focus="${task.action || task.section}">Focus</button>
+                    </div>
+                  </div>
+                `;
+              }).join('') : '<div class="salesos-empty">No tasks in this mode yet.</div>'}
+            </div>
+          </div>
+          <div class="salesos-card">
+            <div class="salesos-eyebrow">Role Surface</div>
+            <div class="salesos-side-list">
+              <div class="salesos-side-item"><strong>Salesperson</strong><br><span class="salesos-sub">Execution, queue movement, listing review, and output speed.</span></div>
+              <div class="salesos-side-item"><strong>Manager</strong><br><span class="salesos-sub">Review pressure, team visibility, revenue leaks, and inventory health.</span></div>
+              <div class="salesos-side-item"><strong>Hybrid</strong><br><span class="salesos-sub">Sales workflow plus affiliate / growth activity on the same surface.</span></div>
+              <div class="salesos-side-item"><strong>Why this matters</strong><br><span class="salesos-sub">This layer turns the dashboard into a task-driven operator surface instead of a static card wall.</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+
+    const modeSelect = document.getElementById('salesosModeSelect');
+    if (modeSelect) {
+      modeSelect.addEventListener('change', () => {
+        NS.state?.set?.('workflow.mode', modeSelect.value);
+        renderSalesOS({ reason: 'mode_change' });
+      }, { once: true });
+    }
+
+    const roleSelect = document.getElementById('salesosRoleSelect');
+    if (roleSelect) {
+      roleSelect.addEventListener('change', () => {
+        NS.state?.set?.('workflow.role', roleSelect.value);
+        renderSalesOS({ reason: 'role_change' });
+      }, { once: true });
+    }
+
+    mount.querySelectorAll('[data-salesos-open]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const section = button.getAttribute('data-salesos-open') || 'overview';
+        if (typeof window.showSection === 'function') window.showSection(section);
+      }, { once: true });
+    });
+
+    mount.querySelectorAll('[data-salesos-focus]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const focusLabel = clean(button.getAttribute('data-salesos-focus') || 'task');
+        const status = document.getElementById('bootStatus');
+        if (status) status.textContent = `Sales OS focus: ${focusLabel}`;
+      }, { once: true });
+    });
+  }
+
+  NS.phase5workflow = { renderSalesOS, buildWorkflowTasks };
+  NS.modules = NS.modules || {};
+  NS.modules.phase5workflow = true;
+})();

--- a/stabilization/bundle-2/dashboard.js
+++ b/stabilization/bundle-2/dashboard.js
@@ -1,0 +1,72 @@
+(() => {
+  if (window.__ELEVATE_DASHBOARD_PHASE4_LOADER__) {
+    console.warn('[Elevate Dashboard] Phase 4 loader already initialized.');
+    return;
+  }
+  window.__ELEVATE_DASHBOARD_PHASE4_LOADER__ = true;
+
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  NS.version = 'phase4-loader-bundle-2';
+  NS.modules = NS.modules || {};
+  NS.events = NS.events || new EventTarget();
+
+  const MODULES = [
+    '/dashboard-state.js?v=20260407b2',
+    '/dashboard-ui.js?v=20260407b2',
+    '/dashboard-api.js?v=20260407b2',
+    '/dashboard-overview.js?v=20260407b2',
+    '/dashboard-listings.js?v=20260407b2',
+    '/dashboard-profile.js?v=20260407b2',
+    '/dashboard-tools.js?v=20260407b2',
+    '/dashboard-analytics.js?v=20260407b2',
+    '/dashboard-affiliate.js?v=20260407b2',
+    '/dashboard-billing.js?v=20260407b2',
+    '/dashboard-dom-ready-bridge.js?v=20260407b2',
+    '/dashboard-legacy.js?v=20260407b2',
+    '/dashboard-phase4-boot.js?v=20260407b2',
+    '/dashboard-bootstrap.js?v=20260407b2'
+  ];
+
+  function setBootStatus(message) {
+    const status = document.getElementById('bootStatus');
+    if (status) status.textContent = message || '';
+  }
+
+  function hasScript(pathname) {
+    return Array.from(document.scripts).some((script) => {
+      try {
+        return script.src && new URL(script.src, window.location.origin).pathname === pathname;
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  function loadScript(src) {
+    return new Promise((resolve, reject) => {
+      const pathname = src.split('?')[0];
+      if (hasScript(pathname)) {
+        resolve();
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = false;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error(`Failed to load ${src}`));
+      document.head.appendChild(script);
+    });
+  }
+
+  async function loadSequentially() {
+    for (const src of MODULES) {
+      await loadScript(src);
+    }
+  }
+
+  loadSequentially().catch((error) => {
+    console.error('[Elevate Dashboard] Phase 4 loader error:', error);
+    setBootStatus(`Phase 4 loader failed: ${error.message || 'Unknown error'}`);
+  });
+})();


### PR DESCRIPTION
## Summary

This PR adds **Bundle 2** for the website-side dashboard issue shown in the latest screenshots.

The current symptom is:
- shell renders
- sidebar renders
- page stays on `Loading dashboard...`
- no real hydration begins

## Root cause targeted in this bundle

The dashboard loader injects scripts dynamically. That means `dashboard-legacy.js` can load **after** `DOMContentLoaded` has already fired.

When that happens, the legacy file attaches a `DOMContentLoaded` listener too late, so its main boot sequence never runs.

That leaves the page stuck on the static shell.

## What Bundle 2 includes

### 1. DOM-ready bridge
A new `dashboard-dom-ready-bridge.js` file makes late `DOMContentLoaded` listeners execute immediately when the document is already ready.

### 2. Loader update
`dashboard.js` is updated so the DOM-ready bridge loads before `dashboard-legacy.js`.

### 3. Bootstrap cleanup
`dashboard-bootstrap.js` is rewritten to stop redispatching synthetic `DOMContentLoaded` events.
Bootstrap should observe readiness, not fake browser lifecycle events.

### 4. Phase-4 hardening
`dashboard-phase4-boot.js` now narrows rerenders to targeted state keys instead of broad rerender-on-every-state-change behavior.

### 5. Phase-5 isolation
`dashboard-phase5-workflow.js` is included as a render-only version so Sales OS no longer writes back into state during task-build render paths.

## Files added

- `stabilization/bundle-2/README.md`
- `stabilization/bundle-2/dashboard.js`
- `stabilization/bundle-2/dashboard-dom-ready-bridge.js`
- `stabilization/bundle-2/dashboard-bootstrap.js`
- `stabilization/bundle-2/dashboard-phase4-boot.js`
- `stabilization/bundle-2/dashboard-phase5-workflow.js`

## Apply steps

Copy each bundle file to the matching root path:

- `stabilization/bundle-2/dashboard.js` -> `/dashboard.js`
- `stabilization/bundle-2/dashboard-dom-ready-bridge.js` -> `/dashboard-dom-ready-bridge.js`
- `stabilization/bundle-2/dashboard-bootstrap.js` -> `/dashboard-bootstrap.js`
- `stabilization/bundle-2/dashboard-phase4-boot.js` -> `/dashboard-phase4-boot.js`
- `stabilization/bundle-2/dashboard-phase5-workflow.js` -> `/dashboard-phase5-workflow.js`

## Expected outcome

After applying Bundle 2:
- legacy boot should run even when loaded after DOM ready
- the dashboard should begin real hydration instead of sitting on the static shell
- bootstrap should stop forcing synthetic page lifecycle events
- Sales OS should stay isolated from recursive state writes

## Recommended test order

1. open `/dashboard.html`
2. confirm boot telemetry appears
3. confirm user/session/listing hydration starts
4. confirm the page stops saying `Loading dashboard...`
5. confirm Sales OS renders without freezing the page
6. verify `/dashboard.html?safe=1` still works if Bundle 1 changes are also present
