### PR TITLE
Dashboard stabilization bundle 3: legacy boot singleton and sync-user duplicate hardening

### DIFF
--- a/stabilization/bundle-3/README.md
+++ b/stabilization/bundle-3/README.md
@@ -1,0 +1,47 @@
+# Dashboard Stabilization Bundle 3
+
+This bundle targets the current failure mode after Bundle 2 testing:
+
+- dashboard shell renders
+- page stays on `Loading dashboard...`
+- Vercel shows `/api/sync-user` requests with duplicate-email errors
+- dashboard appears to restart or spin without reaching a stable hydrated state
+
+## What Bundle 3 fixes
+
+### 1. Legacy boot registration
+Adds a dedicated `dashboard-legacy-boot-bridge.js` that captures the late `DOMContentLoaded` boot callback from `dashboard-legacy.js`, exposes it as a callable boot function, and guarantees it only runs once unless manually retried.
+
+### 2. Loader ordering
+Updates `dashboard.js` so the legacy boot bridge loads before `dashboard-legacy.js`.
+
+### 3. Bootstrap de-looping
+Updates `dashboard-bootstrap.js` to call the registered legacy boot only once and then watch readiness instead of repeatedly retriggering startup.
+
+### 4. sync-user duplicate email hardening
+Replaces the current `users` table upsert behavior with a lookup/update/insert flow that avoids the `users_email_key` duplicate error.
+
+## Files in this bundle
+
+Copy these files into the repo root exactly as mapped below:
+
+- `stabilization/bundle-3/dashboard.js` -> `/dashboard.js`
+- `stabilization/bundle-3/dashboard-legacy-boot-bridge.js` -> `/dashboard-legacy-boot-bridge.js`
+- `stabilization/bundle-3/dashboard-bootstrap.js` -> `/dashboard-bootstrap.js`
+- `stabilization/bundle-3/api-sync-user.js` -> `/api/sync-user.js`
+
+## Expected result
+
+After applying Bundle 3:
+
+- legacy dashboard boot should be registered and callable
+- the boot path should stop looping
+- `sync-user` should stop throwing duplicate-email console errors
+- the dashboard should either hydrate normally or fail in a narrower, easier-to-diagnose place
+
+## Test order
+
+1. Open `/dashboard.html`
+2. Confirm the loading shell clears or at least progresses farther than before
+3. Check Vercel logs and confirm `sync-user` no longer logs the duplicate email error
+4. Retry login -> dashboard flow and verify the page does not keep re-entering startup

--- a/stabilization/bundle-3/api-sync-user.js
+++ b/stabilization/bundle-3/api-sync-user.js
@@ -1,0 +1,155 @@
+import { supabase } from '../lib/supabase.js';
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+export default async function handler(req, res) {
+  if (req.method === 'OPTIONS') {
+    return res.status(200).set(CORS).end();
+  }
+
+  Object.entries(CORS).forEach(([k, v]) => res.setHeader(k, v));
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const authHeader = req.headers.authorization || '';
+  if (!authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Missing auth token' });
+  }
+
+  const token = authHeader.slice(7);
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+
+  const email = user.email?.toLowerCase();
+  const authUid = user.id;
+
+  try {
+    let userRow = null;
+
+    const { data: existingByAuth, error: existingByAuthError } = await supabase
+      .from('users')
+      .select('id, auth_user_id, email')
+      .eq('auth_user_id', authUid)
+      .maybeSingle();
+
+    if (existingByAuthError) {
+      console.error('[sync-user] users auth lookup error:', existingByAuthError.message);
+    }
+
+    if (existingByAuth) {
+      const { data: updatedUser, error: updateByAuthError } = await supabase
+        .from('users')
+        .update({
+          email,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', existingByAuth.id)
+        .select('id, auth_user_id, email')
+        .maybeSingle();
+
+      if (updateByAuthError) {
+        console.error('[sync-user] users update-by-auth error:', updateByAuthError.message);
+      } else {
+        userRow = updatedUser;
+      }
+    }
+
+    if (!userRow && email) {
+      const { data: existingByEmail, error: existingByEmailError } = await supabase
+        .from('users')
+        .select('id, auth_user_id, email')
+        .eq('email', email)
+        .maybeSingle();
+
+      if (existingByEmailError) {
+        console.error('[sync-user] users email lookup error:', existingByEmailError.message);
+      }
+
+      if (existingByEmail) {
+        const { data: updatedUser, error: updateByEmailError } = await supabase
+          .from('users')
+          .update({
+            auth_user_id: authUid,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', existingByEmail.id)
+          .select('id, auth_user_id, email')
+          .maybeSingle();
+
+        if (updateByEmailError) {
+          console.error('[sync-user] users update-by-email error:', updateByEmailError.message);
+        } else {
+          userRow = updatedUser;
+        }
+      }
+    }
+
+    if (!userRow) {
+      const { data: insertedUser, error: insertUserError } = await supabase
+        .from('users')
+        .insert({
+          auth_user_id: authUid,
+          email,
+          updated_at: new Date().toISOString(),
+        })
+        .select('id, auth_user_id, email')
+        .maybeSingle();
+
+      if (insertUserError) {
+        console.error('[sync-user] users insert error:', insertUserError.message);
+      } else {
+        userRow = insertedUser;
+      }
+    }
+
+    const { data: existingProfile } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('id', authUid)
+      .maybeSingle();
+
+    if (!existingProfile) {
+      const { error: profileError } = await supabase
+        .from('profiles')
+        .insert({ id: authUid, email });
+
+      if (profileError && profileError.code !== '23505') {
+        console.error('[sync-user] profile insert error:', profileError.message);
+      }
+    }
+
+    if (userRow) {
+      const { data: existingSub } = await supabase
+        .from('subscriptions')
+        .select('id')
+        .eq('user_id', userRow.id)
+        .maybeSingle();
+
+      if (!existingSub) {
+        const { error: subError } = await supabase.from('subscriptions').insert({
+          user_id: userRow.id,
+          email,
+          subscription_status: 'none',
+          is_active: false,
+        });
+
+        if (subError && subError.code !== '23505') {
+          console.error('[sync-user] subscription insert error:', subError.message);
+        }
+      }
+    }
+
+    return res.status(200).json({ success: true, userId: authUid, linkedUserId: userRow?.id || null });
+  } catch (err) {
+    console.error('[sync-user] Error:', err.message);
+    return res.status(500).json({ error: err.message });
+  }
+}

--- a/stabilization/bundle-3/dashboard-bootstrap.js
+++ b/stabilization/bundle-3/dashboard-bootstrap.js
@@ -1,0 +1,235 @@
+(() => {
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  if (NS.modules?.bootstrap) return;
+
+  const RETRY_TIMEOUT_MS = 15000;
+  const POLL_MS = 600;
+
+  const CSS = `
+    .ea-boot-panel {
+      margin: 12px 0 18px;
+      padding: 14px 16px;
+      border: 1px solid rgba(212,175,55,0.14);
+      border-radius: 14px;
+      background: rgba(255,255,255,0.02);
+      display: grid;
+      gap: 8px;
+    }
+    .ea-boot-panel-head {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+    .ea-boot-eyebrow {
+      color: #d4af37;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    .ea-boot-badge {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      padding: 0 10px;
+      border-radius: 999px;
+      font-size: 11px;
+      font-weight: 700;
+      border: 1px solid rgba(255,255,255,0.08);
+      background: #171717;
+      color: #f4f4f4;
+    }
+    .ea-boot-badge.running { color: #f3ddb0; border-color: rgba(212,175,55,0.18); }
+    .ea-boot-badge.ready { color: #9de8a8; border-color: rgba(157,232,168,0.22); }
+    .ea-boot-badge.error { color: #ffb4b4; border-color: rgba(255,180,180,0.2); }
+    .ea-boot-title { font-size: 14px; font-weight: 700; }
+    .ea-boot-detail { font-size: 13px; color: #b8b8b8; line-height: 1.5; }
+    .ea-boot-stage-list { display: grid; gap: 6px; }
+    .ea-boot-stage-item { font-size: 12px; color: #d6d6d6; }
+    .ea-boot-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+    .ea-boot-actions button {
+      appearance: none;
+      border: 1px solid rgba(255,255,255,0.08);
+      background: #1a1a1a;
+      color: #f2f2f2;
+      border-radius: 10px;
+      padding: 10px 12px;
+      cursor: pointer;
+      font-size: 12px;
+    }
+  `;
+
+  function qs(selector, root = document) {
+    return root.querySelector(selector);
+  }
+
+  function clean(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function injectStyles() {
+    if (document.getElementById('ea-boot-panel-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'ea-boot-panel-styles';
+    style.textContent = CSS;
+    document.head.appendChild(style);
+  }
+
+  function ensurePanel() {
+    injectStyles();
+    let panel = document.getElementById('eaBootPanel');
+    if (panel) return panel;
+
+    panel = document.createElement('div');
+    panel.id = 'eaBootPanel';
+    panel.className = 'ea-boot-panel';
+    panel.innerHTML = `
+      <div class="ea-boot-panel-head">
+        <div>
+          <div class="ea-boot-eyebrow">Boot Telemetry</div>
+          <div id="eaBootTitle" class="ea-boot-title">Starting dashboard bootstrap...</div>
+        </div>
+        <div id="eaBootBadge" class="ea-boot-badge running">Running</div>
+      </div>
+      <div id="eaBootDetail" class="ea-boot-detail">Preparing telemetry and startup controller.</div>
+      <div id="eaBootStages" class="ea-boot-stage-list"></div>
+      <div class="ea-boot-actions">
+        <button id="eaBootRetryBtn" type="button">Retry bootstrap</button>
+        <button id="eaBootReloadBtn" type="button">Reload page</button>
+      </div>
+    `;
+
+    const header = qs('.main-header') || document.body;
+    header.insertAdjacentElement('afterend', panel);
+
+    const retryBtn = document.getElementById('eaBootRetryBtn');
+    if (retryBtn && retryBtn.dataset.bound !== 'true') {
+      retryBtn.dataset.bound = 'true';
+      retryBtn.addEventListener('click', () => {
+        if (typeof window.__ELEVATE_DASHBOARD_LEGACY_BOOT__ === 'function') {
+          try {
+            window.__ELEVATE_DASHBOARD_LEGACY_BOOT__({ reason: 'manual_retry' });
+          } catch (error) {
+            console.warn('[Elevate Dashboard] retry bootstrap warning:', error);
+          }
+        }
+      });
+    }
+
+    const reloadBtn = document.getElementById('eaBootReloadBtn');
+    if (reloadBtn && reloadBtn.dataset.bound !== 'true') {
+      reloadBtn.dataset.bound = 'true';
+      reloadBtn.addEventListener('click', () => window.location.reload());
+    }
+
+    return panel;
+  }
+
+  function renderStages(stages = []) {
+    const wrap = document.getElementById('eaBootStages');
+    if (!wrap) return;
+    wrap.innerHTML = stages.slice(-6).map((item) => `<div class="ea-boot-stage-item">• ${item}</div>`).join('');
+  }
+
+  function updatePanel(status, title, detail) {
+    ensurePanel();
+    const badge = document.getElementById('eaBootBadge');
+    const titleEl = document.getElementById('eaBootTitle');
+    const detailEl = document.getElementById('eaBootDetail');
+    if (badge) {
+      badge.className = `ea-boot-badge ${status}`;
+      badge.textContent = status === 'ready' ? 'Ready' : status === 'error' ? 'Error' : 'Running';
+    }
+    if (titleEl) titleEl.textContent = title || 'Boot status';
+    if (detailEl) detailEl.textContent = detail || '';
+    const bootStatus = document.getElementById('bootStatus');
+    if (bootStatus) bootStatus.textContent = detail || title || '';
+  }
+
+  function pushStage(label, detail = '') {
+    NS.bootstrapState = NS.bootstrapState || { stages: [] };
+    const line = detail ? `${label}: ${detail}` : label;
+    NS.bootstrapState.stages.push(line);
+    renderStages(NS.bootstrapState.stages);
+    updatePanel('running', label, detail);
+  }
+
+  function getIndicators() {
+    const userEmailText = clean(qs('.user-email')?.textContent || '');
+    const welcomeText = clean(document.getElementById('welcomeText')?.textContent || '');
+    return {
+      shellLoading: /loading/i.test(userEmailText) || /loading dashboard/i.test(welcomeText),
+      hasUser: Boolean(window.currentUser?.id) || (userEmailText && !/loading/i.test(userEmailText)),
+      hasSession: Boolean(window.currentNormalizedSession?.subscription || window.currentAccountData),
+      hasSummary: Boolean(window.dashboardSummary && typeof window.dashboardSummary === 'object'),
+      hasListings: Array.isArray(window.dashboardListings) && window.dashboardListings.length > 0
+    };
+  }
+
+  function runLegacyBootOnce() {
+    if (NS.bootstrapState?.legacyBootRequested) return;
+    if (typeof window.__ELEVATE_DASHBOARD_LEGACY_BOOT__ !== 'function') return;
+
+    NS.bootstrapState.legacyBootRequested = true;
+    pushStage('Legacy Boot', 'Invoking registered dashboard boot.');
+
+    Promise.resolve()
+      .then(() => window.__ELEVATE_DASHBOARD_LEGACY_BOOT__({ reason: 'bootstrap_watch' }))
+      .catch((error) => {
+        console.warn('[Elevate Dashboard] legacy boot trigger warning:', error);
+        updatePanel('error', 'Legacy boot failed', error?.message || 'Unknown legacy boot error');
+      });
+  }
+
+  function startWatch() {
+    ensurePanel();
+    pushStage('Bootstrap', 'Watching shell hydration and dashboard readiness.');
+
+    const startedAt = Date.now();
+    const tick = () => {
+      const indicators = getIndicators();
+      runLegacyBootOnce();
+
+      if (indicators.hasUser && !indicators.hasSummary) {
+        updatePanel('running', 'User resolved', 'Waiting for dashboard summary and workspace hydration.');
+      }
+
+      if (indicators.hasSummary && !indicators.hasSession) {
+        updatePanel('running', 'Summary resolved', 'Waiting for normalized session and section render pass.');
+      }
+
+      if (!indicators.shellLoading && indicators.hasUser && indicators.hasSummary && indicators.hasSession) {
+        pushStage('Ready', 'Core dashboard hydration completed.');
+        updatePanel('ready', 'Dashboard hydrated', indicators.hasListings ? 'Workspace, summary, and listings are available.' : 'Workspace and summary are available. Listings may still be hydrating.');
+        clearInterval(intervalId);
+        return;
+      }
+
+      if (Date.now() - startedAt > RETRY_TIMEOUT_MS) {
+        updatePanel('error', 'Bootstrap stalled', 'Shell is still partially loaded. Retry bootstrap or inspect the next blocking API stage.');
+        clearInterval(intervalId);
+      }
+    };
+
+    const intervalId = setInterval(tick, POLL_MS);
+    tick();
+  }
+
+  function boot() {
+    if (NS.bootstrapState?.started) return;
+    NS.bootstrapState = NS.bootstrapState || {};
+    NS.bootstrapState.started = true;
+    startWatch();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+
+  NS.modules = NS.modules || {};
+  NS.modules.bootstrap = true;
+})();

--- a/stabilization/bundle-3/dashboard-legacy-boot-bridge.js
+++ b/stabilization/bundle-3/dashboard-legacy-boot-bridge.js
@@ -1,0 +1,66 @@
+(() => {
+  if (window.__EA_DASHBOARD_LEGACY_BOOT_BRIDGE__) return;
+  window.__EA_DASHBOARD_LEGACY_BOOT_BRIDGE__ = true;
+
+  const originalAddEventListener = document.addEventListener.bind(document);
+  const originalRemoveEventListener = document.removeEventListener.bind(document);
+  const listenerMap = new WeakMap();
+
+  function invokeBoot(listener, reason = 'bridge') {
+    if (listener.__eaDashboardBootRunning) {
+      return listener.__eaDashboardBootPromise || Promise.resolve();
+    }
+
+    listener.__eaDashboardBootRunning = true;
+    window.__ELEVATE_DASHBOARD_LEGACY_BOOT_RAN__ = true;
+
+    const event = new Event('DOMContentLoaded');
+    event.__ea_reason = reason;
+
+    const promise = Promise.resolve()
+      .then(() => listener.call(document, event))
+      .catch((error) => {
+        console.error('[Elevate Dashboard] legacy boot bridge error:', error);
+        throw error;
+      })
+      .finally(() => {
+        listener.__eaDashboardBootRunning = false;
+      });
+
+    listener.__eaDashboardBootPromise = promise;
+    return promise;
+  }
+
+  document.addEventListener = function patchedAddEventListener(type, listener, options) {
+    if (type === 'DOMContentLoaded' && typeof listener === 'function') {
+      const once = typeof options === 'object' && options && options.once === true;
+      const wrapped = (event) => invokeBoot(listener, event?.__ea_reason || 'dom_ready');
+      listenerMap.set(listener, wrapped);
+
+      window.__ELEVATE_DASHBOARD_LEGACY_BOOT__ = ({ reason = 'manual' } = {}) => {
+        if (reason === 'manual_retry') {
+          listener.__eaDashboardBootRunning = false;
+        }
+        return invokeBoot(listener, reason);
+      };
+
+      if (document.readyState === 'interactive' || document.readyState === 'complete') {
+        queueMicrotask(() => invokeBoot(listener, 'late_load'));
+        return;
+      }
+
+      return originalAddEventListener(type, wrapped, once ? { ...options, once: false } : options);
+    }
+
+    return originalAddEventListener(type, listener, options);
+  };
+
+  document.removeEventListener = function patchedRemoveEventListener(type, listener, options) {
+    if (type === 'DOMContentLoaded' && listenerMap.has(listener)) {
+      const wrapped = listenerMap.get(listener);
+      listenerMap.delete(listener);
+      return originalRemoveEventListener(type, wrapped, options);
+    }
+    return originalRemoveEventListener(type, listener, options);
+  };
+})();

--- a/stabilization/bundle-3/dashboard.js
+++ b/stabilization/bundle-3/dashboard.js
@@ -1,0 +1,72 @@
+(() => {
+  if (window.__ELEVATE_DASHBOARD_PHASE4_LOADER__) {
+    console.warn('[Elevate Dashboard] Phase 4 loader already initialized.');
+    return;
+  }
+  window.__ELEVATE_DASHBOARD_PHASE4_LOADER__ = true;
+
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  NS.version = 'phase4-loader-bundle-3';
+  NS.modules = NS.modules || {};
+  NS.events = NS.events || new EventTarget();
+
+  const MODULES = [
+    '/dashboard-state.js?v=20260407b3',
+    '/dashboard-ui.js?v=20260407b3',
+    '/dashboard-api.js?v=20260407b3',
+    '/dashboard-overview.js?v=20260407b3',
+    '/dashboard-listings.js?v=20260407b3',
+    '/dashboard-profile.js?v=20260407b3',
+    '/dashboard-tools.js?v=20260407b3',
+    '/dashboard-analytics.js?v=20260407b3',
+    '/dashboard-affiliate.js?v=20260407b3',
+    '/dashboard-billing.js?v=20260407b3',
+    '/dashboard-legacy-boot-bridge.js?v=20260407b3',
+    '/dashboard-legacy.js?v=20260407b3',
+    '/dashboard-phase4-boot.js?v=20260407b3',
+    '/dashboard-bootstrap.js?v=20260407b3'
+  ];
+
+  function setBootStatus(message) {
+    const status = document.getElementById('bootStatus');
+    if (status) status.textContent = message || '';
+  }
+
+  function hasScript(pathname) {
+    return Array.from(document.scripts).some((script) => {
+      try {
+        return script.src && new URL(script.src, window.location.origin).pathname === pathname;
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  function loadScript(src) {
+    return new Promise((resolve, reject) => {
+      const pathname = src.split('?')[0];
+      if (hasScript(pathname)) {
+        resolve();
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = false;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error(`Failed to load ${src}`));
+      document.head.appendChild(script);
+    });
+  }
+
+  async function loadSequentially() {
+    for (const src of MODULES) {
+      await loadScript(src);
+    }
+  }
+
+  loadSequentially().catch((error) => {
+    console.error('[Elevate Dashboard] Phase 4 loader error:', error);
+    setBootStatus(`Phase 4 loader failed: ${error.message || 'Unknown error'}`);
+  });
+})();


### PR DESCRIPTION
## Summary

This PR adds **Bundle 3** for the current dashboard behavior:

- dashboard shell renders
- dashboard page stays on `Loading dashboard...`
- boot appears to re-enter or spin
- Vercel logs show `/api/sync-user` duplicate email errors

## What this bundle targets

### 1. Legacy boot singleton registration
A new `dashboard-legacy-boot-bridge.js` captures the late `DOMContentLoaded` callback from `dashboard-legacy.js`, exposes it as a callable boot function, and guarantees the boot callback only runs once unless manually retried.

### 2. Loader ordering
`dashboard.js` is updated so the legacy boot bridge loads before `dashboard-legacy.js`.

### 3. Bootstrap de-looping
`dashboard-bootstrap.js` now calls the registered legacy boot once, then watches readiness instead of repeatedly retriggering startup.

### 4. sync-user duplicate email hardening
`api/sync-user.js` is replaced with a lookup/update/insert flow so the `users_email_key` duplicate error should stop occurring.

## Files added

- `stabilization/bundle-3/README.md`
- `stabilization/bundle-3/dashboard.js`
- `stabilization/bundle-3/dashboard-legacy-boot-bridge.js`
- `stabilization/bundle-3/dashboard-bootstrap.js`
- `stabilization/bundle-3/api-sync-user.js`

## Apply steps

Copy each bundle file to the matching root path:

- `stabilization/bundle-3/dashboard.js` -> `/dashboard.js`
- `stabilization/bundle-3/dashboard-legacy-boot-bridge.js` -> `/dashboard-legacy-boot-bridge.js`
- `stabilization/bundle-3/dashboard-bootstrap.js` -> `/dashboard-bootstrap.js`
- `stabilization/bundle-3/api-sync-user.js` -> `/api/sync-user.js`

## Expected outcome

After applying Bundle 3:
- legacy dashboard boot should be registered and callable
- the boot path should stop looping
- `sync-user` should stop logging duplicate-email errors
- the dashboard should either hydrate normally or fail in a much narrower place

## Recommended test order

1. open `/dashboard.html`
2. verify the loading shell clears or at least progresses farther
3. verify Vercel no longer logs the duplicate email sync-user error
4. retry login -> dashboard flow and confirm the page does not keep re-entering startup
