### PR TITLE
Dashboard stabilization bundle 4: one-time legacy boot dispatch and direct sync-user root fix

### DIFF
--- a/stabilization/bundle-4/README.md
+++ b/stabilization/bundle-4/README.md
@@ -1,0 +1,55 @@
+# Dashboard Stabilization Bundle 4
+
+This bundle targets the current post-Bundle-3 behavior:
+
+- dashboard shell still sits on `Loading dashboard...`
+- Chrome can hit `RESULT_CODE_HUNG`
+- Vercel still shows the old `/api/sync-user` duplicate-email error, which suggests the prior sync-user fix was not actually applied to the live root file
+
+## Bundle 4 approach
+
+Bundle 4 removes the bridge complexity and switches to a simpler, narrower boot recovery strategy.
+
+## What Bundle 4 changes
+
+### 1. One-time post-legacy DOM boot dispatch
+`dashboard.js` now dispatches a synthetic `DOMContentLoaded` **once** immediately after `dashboard-legacy.js` is loaded, but only if the document is already ready.
+
+This is much narrower than the earlier bootstrap-loop behavior:
+- it happens one time only
+- it happens at loader time only
+- it happens before phase-4 boot and bootstrap are loaded
+
+### 2. Passive bootstrap watcher
+`dashboard-bootstrap.js` is reduced to a passive readiness watcher.
+It no longer tries to invoke legacy boot or re-enter startup.
+
+### 3. Direct sync-user root replacement
+Bundle 4 includes the replacement file at the real mapped path:
+- `stabilization/bundle-4/api/sync-user.js` -> `/api/sync-user.js`
+
+That should stop the duplicate `users_email_key` issue once actually copied into the live root.
+
+## Files in this bundle
+
+Copy these files into the repo root exactly as mapped below:
+
+- `stabilization/bundle-4/dashboard.js` -> `/dashboard.js`
+- `stabilization/bundle-4/dashboard-bootstrap.js` -> `/dashboard-bootstrap.js`
+- `stabilization/bundle-4/api/sync-user.js` -> `/api/sync-user.js`
+
+## Expected result
+
+After applying Bundle 4:
+- legacy boot should have one clean chance to start even when loaded after DOM ready
+- bootstrap should stop contributing to startup re-entry
+- `sync-user` should stop logging duplicate email errors once the root file is replaced
+- the dashboard should either hydrate or fail in a more isolated, debuggable stage
+
+## Test order
+
+1. Copy the three files into the live root paths
+2. Open `/dashboard.html`
+3. Confirm whether the shell progresses past `Loading dashboard...`
+4. Check Vercel logs and confirm `/api/sync-user` no longer logs the duplicate key error
+5. If the page still stalls, the next blocker is likely inside `dashboard-legacy.js` boot internals rather than the loader/bootstrap chain

--- a/stabilization/bundle-4/api/sync-user.js
+++ b/stabilization/bundle-4/api/sync-user.js
@@ -1,0 +1,121 @@
+import { supabase } from '../../lib/supabase.js';
+
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+export default async function handler(req, res) {
+  if (req.method === 'OPTIONS') {
+    return res.status(200).set(CORS).end();
+  }
+
+  Object.entries(CORS).forEach(([k, v]) => res.setHeader(k, v));
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const authHeader = req.headers.authorization || '';
+  if (!authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Missing auth token' });
+  }
+
+  const token = authHeader.slice(7);
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+
+  const email = user.email?.toLowerCase();
+  const authUid = user.id;
+
+  try {
+    let userRow = null;
+
+    const { data: byAuth } = await supabase
+      .from('users')
+      .select('id, auth_user_id, email')
+      .eq('auth_user_id', authUid)
+      .maybeSingle();
+
+    if (byAuth) {
+      const { data: updated } = await supabase
+        .from('users')
+        .update({ email, updated_at: new Date().toISOString() })
+        .eq('id', byAuth.id)
+        .select('id, auth_user_id, email')
+        .maybeSingle();
+      userRow = updated || byAuth;
+    }
+
+    if (!userRow && email) {
+      const { data: byEmail } = await supabase
+        .from('users')
+        .select('id, auth_user_id, email')
+        .eq('email', email)
+        .maybeSingle();
+
+      if (byEmail) {
+        const { data: updated } = await supabase
+          .from('users')
+          .update({ auth_user_id: authUid, updated_at: new Date().toISOString() })
+          .eq('id', byEmail.id)
+          .select('id, auth_user_id, email')
+          .maybeSingle();
+        userRow = updated || byEmail;
+      }
+    }
+
+    if (!userRow) {
+      const { data: inserted, error: insertUserError } = await supabase
+        .from('users')
+        .insert({ auth_user_id: authUid, email, updated_at: new Date().toISOString() })
+        .select('id, auth_user_id, email')
+        .maybeSingle();
+
+      if (insertUserError) {
+        console.error('[sync-user] users insert error:', insertUserError.message);
+      }
+      userRow = inserted || null;
+    }
+
+    const { data: existingProfile } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('id', authUid)
+      .maybeSingle();
+
+    if (!existingProfile) {
+      const { error: profileError } = await supabase
+        .from('profiles')
+        .insert({ id: authUid, email });
+      if (profileError && profileError.code !== '23505') {
+        console.error('[sync-user] profile insert error:', profileError.message);
+      }
+    }
+
+    if (userRow) {
+      const { data: existingSub } = await supabase
+        .from('subscriptions')
+        .select('id')
+        .eq('user_id', userRow.id)
+        .maybeSingle();
+
+      if (!existingSub) {
+        const { error: subError } = await supabase
+          .from('subscriptions')
+          .insert({ user_id: userRow.id, email, subscription_status: 'none', is_active: false });
+        if (subError && subError.code !== '23505') {
+          console.error('[sync-user] subscription insert error:', subError.message);
+        }
+      }
+    }
+
+    return res.status(200).json({ success: true, userId: authUid, linkedUserId: userRow?.id || null });
+  } catch (err) {
+    console.error('[sync-user] Error:', err.message);
+    return res.status(500).json({ error: err.message });
+  }
+}

--- a/stabilization/bundle-4/dashboard-bootstrap.js
+++ b/stabilization/bundle-4/dashboard-bootstrap.js
@@ -1,0 +1,64 @@
+(() => {
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  if (NS.modules?.bootstrap) return;
+
+  const RETRY_TIMEOUT_MS = 15000;
+  const POLL_MS = 600;
+
+  function clean(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function getIndicators() {
+    const userEmailText = clean(document.querySelector('.user-email')?.textContent || '');
+    const welcomeText = clean(document.getElementById('welcomeText')?.textContent || '');
+    return {
+      shellLoading: /loading/i.test(userEmailText) || /loading dashboard/i.test(welcomeText),
+      hasUser: Boolean(window.currentUser?.id) || (userEmailText && !/loading/i.test(userEmailText)),
+      hasSession: Boolean(window.currentNormalizedSession?.subscription || window.currentAccountData),
+      hasSummary: Boolean(window.dashboardSummary && typeof window.dashboardSummary === 'object'),
+      hasListings: Array.isArray(window.dashboardListings) && window.dashboardListings.length > 0
+    };
+  }
+
+  function setBootStatus(text) {
+    const status = document.getElementById('bootStatus');
+    if (status) status.textContent = text || '';
+  }
+
+  function startWatch() {
+    setBootStatus('Watching dashboard readiness...');
+    const startedAt = Date.now();
+
+    const intervalId = setInterval(() => {
+      const indicators = getIndicators();
+
+      if (!indicators.shellLoading && indicators.hasUser && indicators.hasSummary && indicators.hasSession) {
+        setBootStatus(indicators.hasListings ? 'Dashboard ready.' : 'Dashboard ready. Listings may still be hydrating.');
+        clearInterval(intervalId);
+        return;
+      }
+
+      if (Date.now() - startedAt > RETRY_TIMEOUT_MS) {
+        setBootStatus('Bootstrap stalled. Remaining blocker is likely inside legacy boot internals or an API stage.');
+        clearInterval(intervalId);
+      }
+    }, POLL_MS);
+  }
+
+  function boot() {
+    if (NS.bootstrapState?.started) return;
+    NS.bootstrapState = NS.bootstrapState || {};
+    NS.bootstrapState.started = true;
+    startWatch();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+
+  NS.modules = NS.modules || {};
+  NS.modules.bootstrap = true;
+})();

--- a/stabilization/bundle-4/dashboard.js
+++ b/stabilization/bundle-4/dashboard.js
@@ -1,0 +1,85 @@
+(() => {
+  if (window.__ELEVATE_DASHBOARD_PHASE4_LOADER__) {
+    console.warn('[Elevate Dashboard] Phase 4 loader already initialized.');
+    return;
+  }
+  window.__ELEVATE_DASHBOARD_PHASE4_LOADER__ = true;
+
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+  NS.version = 'phase4-loader-bundle-4';
+  NS.modules = NS.modules || {};
+  NS.events = NS.events || new EventTarget();
+
+  const MODULES = [
+    '/dashboard-state.js?v=20260407b4',
+    '/dashboard-ui.js?v=20260407b4',
+    '/dashboard-api.js?v=20260407b4',
+    '/dashboard-overview.js?v=20260407b4',
+    '/dashboard-listings.js?v=20260407b4',
+    '/dashboard-profile.js?v=20260407b4',
+    '/dashboard-tools.js?v=20260407b4',
+    '/dashboard-analytics.js?v=20260407b4',
+    '/dashboard-affiliate.js?v=20260407b4',
+    '/dashboard-billing.js?v=20260407b4',
+    '/dashboard-legacy.js?v=20260407b4',
+    '/dashboard-phase4-boot.js?v=20260407b4',
+    '/dashboard-bootstrap.js?v=20260407b4'
+  ];
+
+  function setBootStatus(message) {
+    const status = document.getElementById('bootStatus');
+    if (status) status.textContent = message || '';
+  }
+
+  function hasScript(pathname) {
+    return Array.from(document.scripts).some((script) => {
+      try {
+        return script.src && new URL(script.src, window.location.origin).pathname === pathname;
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  function loadScript(src) {
+    return new Promise((resolve, reject) => {
+      const pathname = src.split('?')[0];
+      if (hasScript(pathname)) {
+        resolve();
+        return;
+      }
+
+      const script = document.createElement('script');
+      script.src = src;
+      script.async = false;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error(`Failed to load ${src}`));
+      document.head.appendChild(script);
+    });
+  }
+
+  function dispatchLegacyDomReadyOnce() {
+    if (window.__EA_LEGACY_DOM_BOOT_DISPATCHED__) return;
+    if (document.readyState === 'loading') return;
+    window.__EA_LEGACY_DOM_BOOT_DISPATCHED__ = true;
+    try {
+      document.dispatchEvent(new Event('DOMContentLoaded', { bubbles: true, cancelable: true }));
+    } catch (error) {
+      console.warn('[Elevate Dashboard] legacy DOM boot dispatch warning:', error);
+    }
+  }
+
+  async function loadSequentially() {
+    for (const src of MODULES) {
+      await loadScript(src);
+      if (src.includes('/dashboard-legacy.js')) {
+        dispatchLegacyDomReadyOnce();
+      }
+    }
+  }
+
+  loadSequentially().catch((error) => {
+    console.error('[Elevate Dashboard] Phase 4 loader error:', error);
+    setBootStatus(`Phase 4 loader failed: ${error.message || 'Unknown error'}`);
+  });
+})();


### PR DESCRIPTION
## Summary

This PR adds **Bundle 4** for the current post-Bundle-3 behavior:

- dashboard shell still sits on `Loading dashboard...`
- Chrome can hit `RESULT_CODE_HUNG`
- Vercel still shows the old `/api/sync-user` duplicate-email error, which strongly suggests the prior sync-user fix was not copied into the live root file

## What Bundle 4 changes

### 1. One-time post-legacy DOM boot dispatch
`dashboard.js` now dispatches a synthetic `DOMContentLoaded` **once** immediately after `dashboard-legacy.js` is loaded, but only if the document is already ready.

This is intentionally narrower than the earlier bridge/bootstrap experiments:
- one time only
- loader-time only
- before phase-4 boot and bootstrap are loaded

### 2. Passive bootstrap watcher
`dashboard-bootstrap.js` is reduced to a passive readiness watcher.
It no longer tries to invoke legacy boot or re-enter startup.

### 3. Direct sync-user root replacement path
This PR includes the replacement file at the correct mapped path inside the bundle:
- `stabilization/bundle-4/api/sync-user.js` -> `/api/sync-user.js`

That should stop the duplicate `users_email_key` issue once actually copied into the live root.

## Files added

- `stabilization/bundle-4/README.md`
- `stabilization/bundle-4/dashboard.js`
- `stabilization/bundle-4/dashboard-bootstrap.js`
- `stabilization/bundle-4/api/sync-user.js`

## Apply steps

Copy each bundle file to the matching root path:

- `stabilization/bundle-4/dashboard.js` -> `/dashboard.js`
- `stabilization/bundle-4/dashboard-bootstrap.js` -> `/dashboard-bootstrap.js`
- `stabilization/bundle-4/api/sync-user.js` -> `/api/sync-user.js`

## Expected outcome

After applying Bundle 4:
- legacy boot should get one clean chance to start even when loaded after DOM ready
- bootstrap should stop contributing to startup re-entry
- `sync-user` should stop logging duplicate email errors once the root file is replaced
- the dashboard should either hydrate or fail in a much more isolated stage

## Recommended test order

1. copy the three files into the live root paths
2. open `/dashboard.html`
3. confirm whether the shell progresses past `Loading dashboard...`
4. check Vercel logs and confirm `/api/sync-user` no longer logs the duplicate key error
5. if the page still stalls after this, the next blocker is likely inside `dashboard-legacy.js` boot internals rather than the loader/bootstrap chain
