### PR TITLE
Bundle 1: restore Elevate auth/environment baseline

### DIFF
--- a/beta.html
+++ b/beta.html
@@ -421,6 +421,8 @@
     </div>
   </footer>
 
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="/js/supabase-client.js"></script>
   <script src="beta.js"></script>
 </body>
 </html>

--- a/beta.js
+++ b/beta.js
@@ -1,14 +1,31 @@
-const SUPABASE_URL = "https://teixblbxkoershwgqpym.supabase.co";
-const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRlaXhibGJ4a29lcnNod2dxcHltIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMwODUzMDMsImV4cCI6MjA4ODY2MTMwM30.wxt9zjKhsBuflaFZZT9awZiwckRzYkEl-OLm_4q8qF4";
+function getElevateSupabaseConfig() {
+  const config = window.__ELEVATE_SUPABASE_CONFIG || null;
+  const url = config?.url || window.__ELEVATE_SUPABASE_URL || "";
+  const apiKey =
+    config?.publishableKey ||
+    window.__ELEVATE_SUPABASE_PUBLISHABLE_KEY ||
+    window.__ELEVATE_SUPABASE_ANON_KEY ||
+    "";
+
+  if (!url || !apiKey) {
+    throw new Error(
+      "Elevate Supabase config is unavailable. Ensure /js/supabase-client.js is loaded before beta.js."
+    );
+  }
+
+  return { url, apiKey };
+}
 
 async function insertIntoSupabase(table, payload) {
-  const response = await fetch(`${SUPABASE_URL}/rest/v1/${table}`, {
+  const { url, apiKey } = getElevateSupabaseConfig();
+
+  const response = await fetch(`${url}/rest/v1/${table}`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "apikey": SUPABASE_ANON_KEY,
-      "Authorization": `Bearer ${SUPABASE_ANON_KEY}`,
-      "Prefer": "return=minimal"
+      apikey: apiKey,
+      Authorization: `Bearer ${apiKey}`,
+      Prefer: "return=minimal"
     },
     body: JSON.stringify(payload)
   });
@@ -72,7 +89,9 @@ document.addEventListener("DOMContentLoaded", function () {
       console.error("Beta feedback error:", error);
       if (statusBox) {
         statusBox.className = "feedback-status error";
-        statusBox.textContent = "There was an issue submitting your feedback. Please try again.";
+        statusBox.textContent =
+          error?.message ||
+          "There was an issue submitting your feedback. Please try again.";
       }
     } finally {
       resetButton(submitButton);

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -1,30 +1,68 @@
 // /js/supabase-client.js
 
 (function () {
+  const config = {
+    url: "https://teixblbxkoershwgqpym.supabase.co",
+    publishableKey: "sb_publishable_low3Lfh2rAsN-kqBlwHF2Q_Kc6OhQLB",
+    legacyAnonKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRlaXhibGJ4a29lcnNod2dxcHltIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMwODUzMDMsImV4cCI6MjA4ODY2MTMwM30.wxt9zjKhsBuflaFZZT9awZiwckRzYkEl-OLm_4q8qF4"
+  };
+
+  if (!config.url || config.url === "YOUR_SUPABASE_URL") {
+    console.error("Elevate Supabase URL is missing in /js/supabase-client.js");
+    return;
+  }
+
+  if (!config.publishableKey || config.publishableKey === "YOUR_SUPABASE_PUBLISHABLE_KEY") {
+    console.error("Elevate Supabase publishable key is missing in /js/supabase-client.js");
+    return;
+  }
+
+  const frozenConfig = Object.freeze({ ...config });
+
+  window.__ELEVATE_SUPABASE_CONFIG = frozenConfig;
+  window.__ELEVATE_SUPABASE_URL = frozenConfig.url;
+  window.__ELEVATE_SUPABASE_PUBLISHABLE_KEY = frozenConfig.publishableKey;
+  window.__ELEVATE_SUPABASE_ANON_KEY = frozenConfig.publishableKey;
+  window.__ELEVATE_SUPABASE_LEGACY_ANON_KEY = frozenConfig.legacyAnonKey;
+
+  window.getElevateSupabaseConfig = function () {
+    return window.__ELEVATE_SUPABASE_CONFIG;
+  };
+
+  window.getElevateSupabaseClient = function () {
+    if (window.supabaseClient) {
+      return window.supabaseClient;
+    }
+
+    if (!window.supabase || !window.supabase.createClient) {
+      throw new Error("Supabase CDN client is not loaded.");
+    }
+
+    window.supabaseClient = window.supabase.createClient(
+      frozenConfig.url,
+      frozenConfig.publishableKey,
+      {
+        auth: {
+          autoRefreshToken: true,
+          persistSession: true,
+          detectSessionInUrl: true,
+          flowType: "pkce"
+        }
+      }
+    );
+
+    return window.supabaseClient;
+  };
+
   if (!window.supabase || !window.supabase.createClient) {
-    console.error("Supabase CDN client is not loaded.");
-    return;
-  }
-  const SUPABASE_URL = "https://teixblbxkoershwgqpym.supabase.co";
-  const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRlaXhibGJ4a29lcnNod2dxcHltIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMwODUzMDMsImV4cCI6MjA4ODY2MTMwM30.wxt9zjKhsBuflaFZZT9awZiwckRzYkEl-OLm_4q8qF4";
-
-  if (
-    !SUPABASE_URL ||
-    SUPABASE_URL === "YOUR_SUPABASE_URL" ||
-    !SUPABASE_ANON_KEY ||
-    SUPABASE_ANON_KEY === "YOUR_SUPABASE_ANON_KEY"
-  ) {
-    console.error("Supabase URL or anon key is missing in /js/supabase-client.js");
+    console.warn("Supabase CDN client is not loaded yet. Config was registered without initializing the client.");
     return;
   }
 
-  window.__ELEVATE_SUPABASE_URL = SUPABASE_URL;
-  window.__ELEVATE_SUPABASE_ANON_KEY = SUPABASE_ANON_KEY;
-
-  window.supabaseClient = window.supabase.createClient(
-    SUPABASE_URL,
-    SUPABASE_ANON_KEY
-  );
-
-  console.log("Supabase client initialized.");
+  try {
+    window.getElevateSupabaseClient();
+    console.log("Elevate Supabase client initialized.");
+  } catch (error) {
+    console.error("Failed to initialize Elevate Supabase client:", error);
+  }
 })();

--- a/profile.html
+++ b/profile.html
@@ -463,6 +463,7 @@
     </div>
   </div>
 
+  <script src="/js/supabase-client.js"></script>
   <script src="/profile.js"></script>
 </body>
 </html>

--- a/profile.js
+++ b/profile.js
@@ -4,14 +4,6 @@
 // Persists supported profile fields to Supabase and keeps newer UI-only fields in local storage
 
 (function () {
-  const SUPABASE_URL =
-    window.__ELEVATE_SUPABASE_URL ||
-    "https://teixblbxkoershwgqpym.supabase.co";
-
-  const SUPABASE_ANON_KEY =
-    window.__ELEVATE_SUPABASE_ANON_KEY ||
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRlaXhibGJ4a29lcnNod2dxcHltIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzMwODUzMDMsImV4cCI6MjA4ODY2MTMwM30.wxt9zjKhsBuflaFZZT9awZiwckRzYkEl-OLm_4q8qF4";
-
   const els = {};
   let supabaseClient = null;
   let currentUser = null;
@@ -62,20 +54,12 @@
       return supabaseClient;
     }
 
-    if (!window.supabase || !window.supabase.createClient) {
-      throw new Error("Supabase CDN client is not loaded.");
+    if (typeof window.getElevateSupabaseClient === "function") {
+      supabaseClient = window.getElevateSupabaseClient();
+      return supabaseClient;
     }
 
-    supabaseClient = window.supabase.createClient(
-      SUPABASE_URL,
-      SUPABASE_ANON_KEY
-    );
-
-    window.supabaseClient = supabaseClient;
-    window.__ELEVATE_SUPABASE_URL = SUPABASE_URL;
-    window.__ELEVATE_SUPABASE_ANON_KEY = SUPABASE_ANON_KEY;
-
-    return supabaseClient;
+    throw new Error("Elevate Supabase client helper is not available. Ensure /js/supabase-client.js is loaded before profile.js.");
   }
 
   function escapeHtml(value) {


### PR DESCRIPTION
## Bundle 1 completed scope
This PR restores the Elevate auth/environment baseline without touching Empire.

### What was done
- Restored the Elevate Supabase project (`teixblbxkoershwgqpym`) from inactive to active healthy.
- Verified the canonical Elevate project URL remains `https://teixblbxkoershwgqpym.supabase.co`.
- Verified active client keys for Elevate and switched browser-side usage to the current publishable key.
- Centralized browser Supabase config in `js/supabase-client.js`.
- Updated the profile module to consume the centralized client helper instead of creating its own fallback client.
- Updated the beta portal to load the centralized client/config before `beta.js` and to use the shared config for REST inserts.
- Ensured no Empire project or key was introduced anywhere in this change set.

### Files changed
- `js/supabase-client.js`
- `profile.js`
- `beta.js`
- `beta.html`
- `profile.html`

### Why this matters
Bundle 1 was meant to restore login/session flow and eliminate browser-side environment ambiguity. The main causes were an inactive Supabase project and duplicated hardcoded browser config. This PR removes that duplication and establishes one authoritative browser config path.

### Notes
- No schema migration was required for this bundle.
- I did inspect the connected Elevate Supabase project directly.
- Remaining bundles still need to address deployability, security/account truth, schema authority, metrics correctness, and repo cleanup.

Closes #36 (Bundle 1 portion).