### PR TITLE
Bundle 3: harden auth and remove fallback access authority

### DIFF
--- a/_shared/auth.js
+++ b/_shared/auth.js
@@ -7,6 +7,10 @@ function clean(value) {
   return String(value || "").trim();
 }
 
+function normalizeEmail(value) {
+  return clean(value).toLowerCase();
+}
+
 export function isDashboardClient(req) {
   return clean(req?.headers?.["x-elevate-client"] || req?.headers?.["X-ELEVATE-CLIENT"] || "").toLowerCase() === "dashboard";
 }
@@ -39,13 +43,23 @@ export async function requireVerifiedDashboardUser(req, res) {
   return verifiedUser;
 }
 
+export async function requireVerifiedUser(req, res) {
+  const verifiedUser = await getVerifiedRequestUser(req);
+  if (!verifiedUser) {
+    res.status(401).setHeader("Content-Type", "application/json");
+    res.send(JSON.stringify({ error: "Unauthorized", requires_auth: true }));
+    return null;
+  }
+  return verifiedUser;
+}
+
 export function getTrustedIdentity({ verifiedUser = null, body = {}, query = {} } = {}) {
   const bodyId = clean(body.id || body.user_id || body.auth_user_id || query.id || query.user_id);
-  const bodyEmail = clean(body.email || query.email).toLowerCase();
+  const bodyEmail = normalizeEmail(body.email || query.email);
   if (verifiedUser?.id || verifiedUser?.email) {
     return {
       id: clean(verifiedUser.id || bodyId),
-      email: clean(verifiedUser.email || bodyEmail).toLowerCase(),
+      email: normalizeEmail(verifiedUser.email || bodyEmail),
       verified: true
     };
   }
@@ -54,4 +68,10 @@ export function getTrustedIdentity({ verifiedUser = null, body = {}, query = {} 
     email: bodyEmail,
     verified: false
   };
+}
+
+export function requireTrustedIdentity({ verifiedUser = null, body = {}, query = {} } = {}) {
+  const trusted = getTrustedIdentity({ verifiedUser, body, query });
+  if (!trusted.verified) return null;
+  return trusted;
 }

--- a/api/extension-state.js
+++ b/api/extension-state.js
@@ -1,6 +1,5 @@
 import { supabase } from '../lib/supabase.js';
-
-const ACCESS_OVERRIDE_EMAILS = new Set(['damian044@icloud.com']);
+import { requireVerifiedUser } from './_shared/auth.js';
 
 function clean(value) {
   return String(value || '').trim();
@@ -13,12 +12,11 @@ function normalizeEmail(value) {
 const CORS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-elevate-client',
 };
 
-function resolveActiveState(subscription = {}, forcedAccess = false) {
+function resolveActiveState(subscription = {}) {
   return Boolean(
-    forcedAccess ||
     subscription?.is_active ||
     subscription?.access_active ||
     subscription?.bridge_access ||
@@ -84,22 +82,13 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  let authUid = null;
-  let email = normalizeEmail(req.query.email);
-
-  const authHeader = req.headers.authorization || '';
-  if (authHeader.startsWith('Bearer ')) {
-    const token = authHeader.slice(7);
-    const { data: { user }, error } = await supabase.auth.getUser(token);
-    if (!error && user) {
-      authUid = user.id;
-      email = normalizeEmail(user.email);
-    }
+  const verifiedUser = await requireVerifiedUser(req, res);
+  if (!verifiedUser) {
+    return;
   }
 
-  if (!email && !authUid) {
-    return res.status(400).json({ error: 'No identity provided' });
-  }
+  const authUid = clean(verifiedUser.id || '');
+  const email = normalizeEmail(verifiedUser.email || '');
 
   try {
     const identity = await resolveIdentity(authUid, email);
@@ -179,11 +168,10 @@ export default async function handler(req, res) {
       usage = data || null;
     }
 
-    const forcedAccess = ACCESS_OVERRIDE_EMAILS.has(normalizedEmail);
-    const active = resolveActiveState(subscription || {}, forcedAccess);
-    const normalizedStatus = forcedAccess ? 'active' : clean(subscription?.subscription_status || 'none');
-    const normalizedPlan = forcedAccess ? 'Pro' : clean(subscription?.plan_type || 'Beta');
-    const postingLimit = forcedAccess ? 25 : Number(subscription?.daily_posting_limit || 5);
+    const active = resolveActiveState(subscription || {});
+    const normalizedStatus = clean(subscription?.subscription_status || 'none');
+    const normalizedPlan = clean(subscription?.plan_type || 'Beta');
+    const postingLimit = Number(subscription?.daily_posting_limit || 5);
     const postsToday = Number(usage?.posts_today ?? usage?.posts_used ?? usage?.used_today ?? 0) || 0;
     const postsRemaining = Math.max(0, postingLimit - postsToday);
     const canPost = active && postsToday < postingLimit;
@@ -201,7 +189,7 @@ export default async function handler(req, res) {
         scanner_type: clean(profile?.scanner_type || '')
       },
       identity: {
-        auth_user_id: clean(authUid || ''),
+        auth_user_id: authUid,
         internal_user_id: internalUserId,
         email: normalizedEmail,
         candidate_user_ids: candidateIds
@@ -211,25 +199,21 @@ export default async function handler(req, res) {
         normalized_status: normalizedStatus,
         plan: normalizedPlan,
         normalized_plan: normalizedPlan,
-
         active,
         isActive: active,
         access_granted: active,
         accessGranted: active,
         bridge_access: Boolean(subscription?.bridge_access || false),
-
         posting_limit: postingLimit,
         daily_posting_limit: postingLimit,
         daily_limit: postingLimit,
         dailyLimit: postingLimit,
-
         posts_today: postsToday,
         postsToday: postsToday,
         posts_remaining: postsRemaining,
         postsRemaining: postsRemaining,
         can_post: canPost,
         canPost: canPost,
-
         trial_end: subscription?.trial_end || null,
         current_period_end: subscription?.current_period_end || null,
         license_key: licenseKey,

--- a/api/get-user-listings.js
+++ b/api/get-user-listings.js
@@ -1,7 +1,7 @@
 
 import { createClient } from "@supabase/supabase-js";
 import { randomUUID } from "node:crypto";
-import { getVerifiedRequestUser, getTrustedIdentity, isDashboardClient } from "./_shared/auth.js";
+import { getVerifiedRequestUser, getTrustedIdentity, requireVerifiedDashboardUser, isDashboardClient } from "./_shared/auth.js";
 import {
   clean,
   normalizeEmail,
@@ -214,15 +214,22 @@ export default async function handler(req, res) {
   if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed", request_id: requestId });
 
   try {
-    const verifiedUser = await getVerifiedRequestUser(req);
-    const trusted = getTrustedIdentity({ verifiedUser, body: req.body || {}, query: req.query || {} });
     const dashboardClient = isDashboardClient(req);
+    const verifiedUser = dashboardClient
+      ? await requireVerifiedDashboardUser(req, res)
+      : await getVerifiedRequestUser(req);
+
+    if (dashboardClient && !verifiedUser) {
+      return;
+    }
+
+    const trusted = getTrustedIdentity({ verifiedUser, body: req.body || {}, query: req.query || {} });
 
     const userId = clean(trusted.id || req.query?.userId || req.query?.user_id || "");
     const email = normalizeEmail(trusted.email || req.query?.email || "");
 
-    if (dashboardClient && !verifiedUser && !(userId || email)) {
-      return res.status(401).json({ error: "Unauthorized", requires_auth: true, request_id: requestId });
+    if (!userId && !email) {
+      return res.status(400).json({ error: "No identity provided", request_id: requestId });
     }
 
     const status = clean(req.query?.status || "").toLowerCase();
@@ -260,7 +267,7 @@ export default async function handler(req, res) {
         total: rows.length,
         unresolved_price_count: rows.filter((row) => !row.price_resolved).length,
         limit,
-        auth_mode: verifiedUser ? "verified_bearer" : (dashboardClient ? "dashboard_identity_fallback" : "query_identity"),
+        auth_mode: verifiedUser ? "verified_bearer" : "query_identity",
         sources: { user_listings: userRows.length, listings: legacyRows.length, merged: mergedMap.size }
       }
     });

--- a/api/profile.js
+++ b/api/profile.js
@@ -1,11 +1,36 @@
 import { supabase } from '../lib/supabase.js';
-import { randomUUID } from 'node:crypto';
+import { requireVerifiedDashboardUser, getTrustedIdentity, requireVerifiedUser } from './_shared/auth.js';
 
 const CORS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-elevate-client',
 };
+
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function normalizeEmail(value) {
+  return clean(value).toLowerCase();
+}
+
+function pickAllowedUpdates(body = {}) {
+  const allowed = [
+    'full_name', 'phone', 'dealership', 'city', 'province',
+    'dealer_phone', 'dealer_email', 'dealer_website', 'inventory_url',
+    'scanner_type', 'listing_location', 'license_number', 'compliance_mode',
+    'booking_link', 'instagram_handle', 'primary_cta', 'dealership_website',
+    'default_seller_name', 'trades_welcome', 'financing_cta',
+    'delivery_available', 'carfax_mention', 'active_disclaimer', 'logo_url',
+  ];
+
+  const updates = {};
+  for (const field of allowed) {
+    if (field in body) updates[field] = body[field];
+  }
+  return updates;
+}
 
 export default async function handler(req, res) {
   if (req.method === 'OPTIONS') {
@@ -13,116 +38,70 @@ export default async function handler(req, res) {
   }
 
   Object.entries(CORS).forEach(([k, v]) => res.setHeader(k, v));
+  res.setHeader('Content-Type', 'application/json');
 
-  // ── Resolve identity ─────────────────────────────────────────────────────
-  // Accept either a Bearer token (auth UID lookup) or a plain email param
-  // for backwards-compat with the extension which still passes ?email=
-  let authUid = null;
-  let email = null;
-
-  const authHeader = req.headers.authorization || '';
-  if (authHeader.startsWith('Bearer ')) {
-    const token = authHeader.slice(7);
-    const { data: { user }, error } = await supabase.auth.getUser(token);
-    if (!error && user) {
-      authUid = user.id;
-      email = user.email;
-    }
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  // Fallback: email from query or body
-  const requestedId = req.query.id || req.body?.id || req.body?.user_id || null;
-  if (!email) {
-    email = req.query.email || req.body?.email;
-  }
+  try {
+    const verifiedUser = req.method === 'POST'
+      ? await requireVerifiedUser(req, res)
+      : await requireVerifiedDashboardUser(req, res);
 
-  if (!email && !authUid) {
-    return res.status(400).json({ error: 'No identity provided' });
-  }
-
-  // ── Normalize email casing (damian044 vs Damian044) ──────────────────────
-  if (email) email = email.toLowerCase();
-
-  // ── GET: load profile ────────────────────────────────────────────────────
-  if (req.method === 'GET') {
-    let query = supabase
-      .from('profiles')
-      .select('*');
-
-    if (authUid) {
-      query = query.eq('id', authUid);
-    } else if (requestedId) {
-      query = query.eq('id', requestedId);
-    } else {
-      query = query.ilike('email', email);
+    if ((req.method === 'POST' || clean(req.headers['x-elevate-client']).toLowerCase() === 'dashboard') && !verifiedUser) {
+      return;
     }
 
-    const { data, error } = await query.maybeSingle();
+    const trusted = getTrustedIdentity({
+      verifiedUser,
+      body: req.body || {},
+      query: req.query || {}
+    });
 
-    if (error) {
-      console.error('[profile GET] Supabase error:', error.message);
-      return res.status(500).json({ error: error.message });
+    const authUid = clean(trusted.id || '');
+    const email = normalizeEmail(trusted.email || '');
+    const requestedId = clean(req.query.id || req.body?.id || req.body?.user_id || '');
+
+    if (req.method === 'GET') {
+      let query = supabase.from('profiles').select('*');
+
+      if (authUid) {
+        query = query.eq('id', authUid);
+      } else if (requestedId) {
+        query = query.eq('id', requestedId);
+      } else if (email) {
+        query = query.ilike('email', email);
+      } else {
+        return res.status(400).json({ error: 'No identity provided' });
+      }
+
+      const { data, error } = await query.maybeSingle();
+
+      if (error) {
+        console.error('[profile GET] Supabase error:', error.message);
+        return res.status(500).json({ error: error.message });
+      }
+
+      return res.status(200).json({ profile: data || null });
     }
 
-    if (!data) {
-      return res.status(200).json({ profile: null });
-    }
-
-    return res.status(200).json({ profile: data });
-  }
-
-  // ── POST: save profile ───────────────────────────────────────────────────
-  if (req.method === 'POST') {
-    const body = req.body || {};
-
-    // Build the update payload — only include fields that were actually sent
-    const allowed = [
-      'full_name', 'phone', 'dealership', 'city', 'province',
-      'dealer_phone', 'dealer_email', 'dealer_website', 'inventory_url',
-      'scanner_type', 'listing_location', 'license_number', 'compliance_mode',
-      // Phase 1 new fields
-      'booking_link', 'instagram_handle', 'primary_cta', 'dealership_website',
-      'default_seller_name', 'trades_welcome', 'financing_cta',
-      'delivery_available', 'carfax_mention', 'active_disclaimer', 'logo_url',
-    ];
-
-    const updates = {};
-    for (const field of allowed) {
-      if (field in body) updates[field] = body[field];
-    }
-
+    const updates = pickAllowedUpdates(req.body || {});
     if (Object.keys(updates).length === 0) {
       return res.status(400).json({ error: 'No valid fields to update' });
     }
 
+    if (!authUid) {
+      return res.status(401).json({ error: 'Unauthorized', requires_auth: true });
+    }
+
     updates.updated_at = new Date().toISOString();
 
-    // Determine the lookup key — prefer auth UID, fallback to email
-    let upsertData;
-    if (authUid) {
-      upsertData = { id: authUid, email: email || body.email?.toLowerCase(), ...updates };
-    } else {
-      // We need the profile's UUID to upsert correctly
-      const { data: existing } = await supabase
-        .from('profiles')
-        .select('id')
-        .ilike('email', email)
-        .maybeSingle();
-
-      if (existing) {
-        upsertData = { id: existing.id, email, ...updates };
-      } else {
-        // First-time save with no auth UID — create with a new UUID
-        const { data: userRow } = await supabase
-          .from('users')
-          .select('auth_user_id')
-          .ilike('email', email)
-          .maybeSingle();
-
-        const profileId = userRow?.auth_user_id || requestedId || randomUUID();
-        upsertData = { id: profileId, email, ...updates };
-      }
-    }
+    const upsertData = {
+      id: authUid,
+      email,
+      ...updates,
+    };
 
     const { data, error } = await supabase
       .from('profiles')
@@ -137,7 +116,8 @@ export default async function handler(req, res) {
 
     console.log(`[profile POST] Saved profile for ${email || authUid} at ${data.updated_at}`);
     return res.status(200).json({ success: true, profile: data });
+  } catch (error) {
+    console.error('[profile] fatal error:', error.message);
+    return res.status(500).json({ error: error.message || 'Internal server error' });
   }
-
-  return res.status(405).json({ error: 'Method not allowed' });
 }


### PR DESCRIPTION
## Bundle 3 completed scope
This PR hardens critical account/access endpoints by removing unsafe fallback behavior and requiring verified auth where it matters most.

### What was done
- Added stricter verified-user helpers in `_shared/auth.js`.
- Updated `api/profile.js` so:
  - dashboard reads require verified dashboard auth,
  - all profile writes require verified auth,
  - unauthenticated profile creation/upserts are no longer allowed.
- Updated `api/get-user-listings.js` so dashboard listing reads require verified auth instead of dashboard fallback identity.
- Updated `api/extension-state.js` so:
  - verified auth is required,
  - the hardcoded `ACCESS_OVERRIDE_EMAILS` bypass was removed,
  - extension/account state is now derived from actual user/subscription/usage data only.

### Why this matters
Bundle 3 was meant to tighten account truth and remove spoofable or hidden access paths. The repo previously had:
- email/query/body identity fallback on critical endpoints,
- a hardcoded email-based access override,
- inconsistent trust rules between dashboard and extension state.

This PR does not finish all security work in the repo, but it closes the most obvious authority gaps on the key endpoints currently involved in profile access, listing access, and extension subscription state.

### Files changed
- `_shared/auth.js`
- `api/profile.js`
- `api/get-user-listings.js`
- `api/extension-state.js`

### Notes
- This PR is intentionally focused on the highest-leverage auth/authority paths.
- Later bundles still need to address schema authority, metrics correctness, and broader cleanup.

Closes #36 (Bundle 3 portion).