### PR TITLE
Bundle 4: harden Elevate schema authority and RLS layer

### DIFF
--- a/supabase/migrations/20260503022000_bundle4_schema_authority_part1.sql
+++ b/supabase/migrations/20260503022000_bundle4_schema_authority_part1.sql
@@ -1,0 +1,165 @@
+create schema if not exists private;
+
+create unique index if not exists posting_usage_user_date_unique_idx
+  on public.posting_usage (user_id, date_key)
+  where user_id is not null and date_key is not null;
+
+alter table public.profiles enable row level security;
+alter table public.users enable row level security;
+alter table public.subscriptions enable row level security;
+alter table public.license_keys enable row level security;
+alter table public.user_credits enable row level security;
+alter table public.credit_events enable row level security;
+alter table public.user_referral_codes enable row level security;
+alter table public.user_post_activity enable row level security;
+alter table public.payouts enable row level security;
+alter table public.organizations enable row level security;
+alter table public.organization_members enable row level security;
+alter table public.dealerships enable row level security;
+alter table public.scanner_configs enable row level security;
+alter table public.affiliates enable row level security;
+alter table public.webhook_events enable row level security;
+alter table public.posting_limits enable row level security;
+alter table public.post_logs enable row level security;
+alter table public.license_activations enable row level security;
+
+create policy "profiles_select_own"
+on public.profiles
+for select
+to authenticated
+using (id = auth.uid() or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', '')));
+
+create policy "profiles_insert_own"
+on public.profiles
+for insert
+to authenticated
+with check (
+  id = auth.uid()
+  and lower(coalesce(email, lower(coalesce(auth.jwt() ->> 'email', '')))) = lower(coalesce(auth.jwt() ->> 'email', ''))
+);
+
+create policy "profiles_update_own"
+on public.profiles
+for update
+to authenticated
+using (id = auth.uid())
+with check (id = auth.uid());
+
+create policy "users_select_own"
+on public.users
+for select
+to authenticated
+using (auth_user_id = auth.uid() or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', '')));
+
+create policy "users_update_own"
+on public.users
+for update
+to authenticated
+using (auth_user_id = auth.uid())
+with check (auth_user_id = auth.uid());
+
+create policy "subscriptions_select_own"
+on public.subscriptions
+for select
+to authenticated
+using (
+  user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+  or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+);
+
+create policy "posting_usage_select_own"
+on public.posting_usage
+for select
+to authenticated
+using (
+  user_id = auth.uid()
+  or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  or user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+create policy "posting_usage_insert_own"
+on public.posting_usage
+for insert
+to authenticated
+with check (
+  user_id = auth.uid()
+  or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  or user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+create policy "posting_usage_update_own"
+on public.posting_usage
+for update
+to authenticated
+using (
+  user_id = auth.uid()
+  or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  or user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+)
+with check (
+  user_id = auth.uid()
+  or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  or user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+create policy "usage_logs_select_own"
+on public.usage_logs
+for select
+to authenticated
+using (
+  user_id = auth.uid()
+  or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  or user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+create policy "user_listings_select_own"
+on public.user_listings
+for select
+to authenticated
+using (
+  user_id = auth.uid()
+  or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  or user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+create policy "listings_select_own"
+on public.listings
+for select
+to authenticated
+using (
+  user_id = auth.uid()
+  or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  or user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);

--- a/supabase/migrations/20260503022100_bundle4_schema_authority_part2.sql
+++ b/supabase/migrations/20260503022100_bundle4_schema_authority_part2.sql
@@ -1,0 +1,238 @@
+create policy "user_credits_select_own"
+on public.user_credits
+for select
+to authenticated
+using (
+  user_id = auth.uid()
+  or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  or user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+create policy "credit_events_select_own"
+on public.credit_events
+for select
+to authenticated
+using (
+  user_id = auth.uid()
+  or lower(coalesce(email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  or user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+create policy "affiliates_select_own"
+on public.affiliates
+for select
+to authenticated
+using (
+  user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+create policy "referrals_select_own"
+on public.referrals
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.affiliates a
+    where a.id = referrals.affiliate_id
+      and a.user_id in (
+        select u.id from public.users u
+        where u.auth_user_id = auth.uid()
+           or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+      )
+  )
+);
+
+create policy "commissions_select_own"
+on public.commissions
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.affiliates a
+    where a.id = commissions.affiliate_id
+      and a.user_id in (
+        select u.id from public.users u
+        where u.auth_user_id = auth.uid()
+           or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+      )
+  )
+);
+
+create policy "payouts_select_own"
+on public.payouts
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.affiliates a
+    where a.id = payouts.affiliate_id
+      and a.user_id in (
+        select u.id from public.users u
+        where u.auth_user_id = auth.uid()
+           or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+      )
+  )
+);
+
+create policy "user_referral_codes_select_own"
+on public.user_referral_codes
+for select
+to authenticated
+using (
+  user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+create policy "user_post_activity_select_own"
+on public.user_post_activity
+for select
+to authenticated
+using (
+  user_id = auth.uid()
+  or user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+);
+
+create policy "organizations_select_member"
+on public.organizations
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.organization_members m
+    where m.organization_id = organizations.id
+      and m.user_id in (
+        select u.id from public.users u
+        where u.auth_user_id = auth.uid()
+           or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+      )
+  )
+);
+
+create policy "organization_members_select_member"
+on public.organization_members
+for select
+to authenticated
+using (
+  user_id in (
+    select u.id from public.users u
+    where u.auth_user_id = auth.uid()
+       or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+  )
+  or exists (
+    select 1
+    from public.organization_members m
+    where m.organization_id = organization_members.organization_id
+      and m.user_id in (
+        select u.id from public.users u
+        where u.auth_user_id = auth.uid()
+           or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+      )
+  )
+);
+
+create policy "dealerships_select_member"
+on public.dealerships
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.organization_members m
+    where m.organization_id = dealerships.organization_id
+      and m.user_id in (
+        select u.id from public.users u
+        where u.auth_user_id = auth.uid()
+           or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+      )
+  )
+);
+
+create policy "scanner_configs_select_member"
+on public.scanner_configs
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.dealerships d
+    join public.organization_members m on m.organization_id = d.organization_id
+    where d.id = scanner_configs.dealership_id
+      and m.user_id in (
+        select u.id from public.users u
+        where u.auth_user_id = auth.uid()
+           or lower(coalesce(u.email, '')) = lower(coalesce(auth.jwt() ->> 'email', ''))
+      )
+  )
+);
+
+create policy "license_keys_no_client_access"
+on public.license_keys
+for select
+to authenticated
+using (false);
+
+create policy "webhook_events_no_client_access"
+on public.webhook_events
+for select
+to authenticated
+using (false);
+
+create policy "posting_limits_no_client_access"
+on public.posting_limits
+for select
+to authenticated
+using (false);
+
+create policy "post_logs_no_client_access"
+on public.post_logs
+for select
+to authenticated
+using (false);
+
+create policy "license_activations_no_client_access"
+on public.license_activations
+for select
+to authenticated
+using (false);
+
+create policy "user_profiles_select_own"
+on public.user_profiles
+for select
+to authenticated
+using (lower(coalesce(user_email, '')) = lower(coalesce(auth.jwt() ->> 'email', '')));
+
+create policy "user_profiles_insert_own"
+on public.user_profiles
+for insert
+to authenticated
+with check (lower(coalesce(user_email, '')) = lower(coalesce(auth.jwt() ->> 'email', '')));
+
+create policy "user_profiles_update_own"
+on public.user_profiles
+for update
+to authenticated
+using (lower(coalesce(user_email, '')) = lower(coalesce(auth.jwt() ->> 'email', '')))
+with check (lower(coalesce(user_email, '')) = lower(coalesce(auth.jwt() ->> 'email', '')));


### PR DESCRIPTION
## Bundle 4 completed scope
This PR captures the Elevate schema authority and RLS hardening work already applied directly to the connected Elevate Supabase project.

### What was done in Supabase
- Enabled RLS on previously exposed public tables tied to account, subscription, credits, affiliate, org, dealership, scanner, and internal operational data.
- Added owner/member-scoped RLS policies for the main Elevate user-facing and account-linked tables.
- Added deny-direct-client-access policies for sensitive/internal tables such as license keys, webhook events, posting limits, post logs, and license activations.
- Added a unique partial index on `public.posting_usage (user_id, date_key)` to tighten usage-record authority and reduce duplicate daily usage rows.
- Kept all work scoped to the Elevate Supabase project only. Empire was not touched.

### Repo changes in this PR
- Added migration snapshot files:
  - `supabase/migrations/20260503022000_bundle4_schema_authority_part1.sql`
  - `supabase/migrations/20260503022100_bundle4_schema_authority_part2.sql`

These files document the schema/RLS hardening that was applied directly in the connected Supabase app so repo state matches live database state.

### Security impact
This bundle materially reduces the prior exposure where multiple `public` tables had RLS disabled or lacked effective access boundaries. After applying the changes, the major advisor findings for RLS-disabled public tables and exposed sensitive columns on the targeted Elevate tables are cleared.

### Remaining items after Bundle 4
The main remaining Supabase security advisories are now:
- `public.user_profiles_view` defined as `SECURITY DEFINER`
- several existing database functions with mutable `search_path`
- intentionally public insert policies on waitlist and beta feedback tables
- leaked password protection disabled in Supabase Auth

These stay in scope for later bundles.

Closes #36 (Bundle 4 portion).