### PR TITLE
Bundle 6: add repo hygiene safety nets and runtime map

### DIFF
--- a/REPO-MAP.md
+++ b/REPO-MAP.md
@@ -1,0 +1,45 @@
+# Elevate Automation Repo Map
+
+## Live runtime surface
+These are the primary live surfaces that should be treated as authoritative before touching older phase artifacts.
+
+### Frontend runtime
+- `dashboard.js` — main dashboard loader
+- `dashboard-phase3-canonical.js` — canonical dashboard truth layer
+- `dashboard-phase21-shell-repair.js` — active shell repair layer
+- `profile.html` / `profile.js` — profile module
+- `beta.html` / `beta.js` — beta portal
+- `js/supabase-client.js` — browser Supabase config authority
+
+### API runtime
+- `api/` — deployed Vercel API surface
+- `api/_shared/` — shared server helpers
+- `_shared/` — shared account/access logic mirrored into API via re-export files
+
+### Schema/runtime docs
+- `supabase/migrations/` — migration snapshots committed during stabilization bundles
+
+## Stabilization bundle outcomes
+- Bundle 1 — auth/environment recovery
+- Bundle 2 — API limit recovery
+- Bundle 3 — auth/access authority hardening
+- Bundle 4 — schema authority + RLS hardening
+- Bundle 5 — dashboard metrics correctness
+- Bundle 6 — repo hygiene + validation safety nets
+
+## Cleanup guidance
+### Treat as deprecated / review-before-use
+- `dashboard-phase21-shell-cleanup.js` — historical artifact, known-invalid/unsafe candidate until replaced or removed cleanly
+- `dashboard-legacy.js` — legacy compatibility layer, not preferred for new work
+- root `auth.js` and root `account-access.js` — suspicious root-level server artifacts; review for deletion or relocation
+- any ZIP artifacts checked into the repo root
+- `stabilization/` historical bundle copies
+
+### Preferred rule
+When changing production behavior, patch the live runtime surface first rather than historical bundle copies or deprecated phase artifacts.
+
+## Validation commands
+- `npm run check:conflicts`
+- `npm run check:dashboard-safety`
+- `npm run check:repo-hygiene`
+- `npm run validate`

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "check:conflicts": "bash scripts/check-conflict-markers.sh"
+    "check:conflicts": "bash scripts/check-conflict-markers.sh",
+    "check:dashboard-safety": "node scripts/check-dashboard-safety.mjs",
+    "check:repo-hygiene": "node scripts/check-repo-hygiene.mjs",
+    "validate": "npm run check:conflicts && npm run check:dashboard-safety && npm run check:repo-hygiene"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.43.4",

--- a/scripts/check-dashboard-safety.mjs
+++ b/scripts/check-dashboard-safety.mjs
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const filesToScan = [
+  "dashboard-phase21-shell-cleanup.js",
+  "dashboard-phase21-shell-repair.js",
+  "dashboard-phase3-canonical.js",
+  "dashboard.js"
+];
+
+const checks = [];
+
+for (const relPath of filesToScan) {
+  const absPath = path.join(repoRoot, relPath);
+  if (!fs.existsSync(absPath)) {
+    checks.push({ file: relPath, ok: false, message: "missing file" });
+    continue;
+  }
+
+  const content = fs.readFileSync(absPath, "utf8");
+
+  const pythonStyleIf = /if\s*\([^\n]+\)\s*:/g.test(content);
+  const pythonStyleFor = /for\s*\([^\n]+\)\s*:/g.test(content);
+  const unresolvedConflict = /<<<<<<<|=======|>>>>>>>/g.test(content);
+
+  if (pythonStyleIf || pythonStyleFor) {
+    checks.push({ file: relPath, ok: false, message: "contains invalid JS control syntax" });
+    continue;
+  }
+
+  if (unresolvedConflict) {
+    checks.push({ file: relPath, ok: false, message: "contains unresolved conflict markers" });
+    continue;
+  }
+
+  checks.push({ file: relPath, ok: true, message: "ok" });
+}
+
+const failed = checks.filter((item) => !item.ok);
+
+for (const item of checks) {
+  const prefix = item.ok ? "[ok]" : "[fail]";
+  console.log(`${prefix} ${item.file} - ${item.message}`);
+}
+
+if (failed.length) {
+  process.exit(1);
+}

--- a/scripts/check-repo-hygiene.mjs
+++ b/scripts/check-repo-hygiene.mjs
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+const forbiddenPatterns = [
+  /elevate-automation-phase-.*\.zip$/i,
+  /elevate-bundle-.*\.zip$/i,
+  /^stabilization\//i
+];
+
+const suspiciousRootFiles = [
+  "auth.js",
+  "account-access.js"
+];
+
+function walk(dir, prefix = "") {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const rel = path.join(prefix, entry.name);
+    const abs = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if ([".git", "node_modules"].includes(entry.name)) continue;
+      results.push(...walk(abs, rel));
+    } else {
+      results.push(rel.replace(/\\/g, "/"));
+    }
+  }
+  return results;
+}
+
+const allFiles = walk(repoRoot);
+const problems = [];
+
+for (const rel of allFiles) {
+  for (const pattern of forbiddenPatterns) {
+    if (pattern.test(rel)) {
+      problems.push(`${rel} matches forbidden cleanup pattern ${pattern}`);
+    }
+  }
+}
+
+for (const rel of suspiciousRootFiles) {
+  const abs = path.join(repoRoot, rel);
+  if (fs.existsSync(abs)) {
+    problems.push(`${rel} still exists at repo root and should be reviewed for removal or relocation`);
+  }
+}
+
+if (!fs.existsSync(path.join(repoRoot, "scripts", "check-dashboard-safety.mjs"))) {
+  problems.push("scripts/check-dashboard-safety.mjs is missing");
+}
+
+if (problems.length) {
+  problems.forEach((msg) => console.error(`[fail] ${msg}`));
+  process.exit(1);
+}
+
+console.log("[ok] repo hygiene checks passed");


### PR DESCRIPTION
## Bundle 6 completed scope
This PR adds lightweight repo hygiene and validation safety nets, plus a runtime map for the live Elevate surface.

### What changed
- Updated `package.json`
- Added `scripts/check-dashboard-safety.mjs`
- Added `scripts/check-repo-hygiene.mjs`
- Added `REPO-MAP.md`

### What this bundle accomplishes
- Adds lightweight validation commands:
  - `npm run check:dashboard-safety`
  - `npm run check:repo-hygiene`
  - `npm run validate`
- Documents the live runtime surface so active files are easier to identify before patching old phase artifacts.
- Adds a safety net to catch:
  - invalid JS control syntax patterns
  - unresolved conflict markers
  - checked-in ZIP artifact patterns
  - lingering suspicious root-level server artifacts
  - stabilization-folder residue

### Important note
This PR intentionally does **not** hard-delete `dashboard-phase21-shell-cleanup.js`, `auth.js`, or `account-access.js` yet. The cleanup targets are now documented and guarded by validation, but I avoided risky direct mutation on those existing files in this pass.

So Bundle 6 delivers:
- safety nets added
- repo map added
- cleanup targets explicitly documented
- validation now guards against those artifact classes remaining or being reintroduced

### Remaining known cleanup after this PR
- `dashboard-phase21-shell-cleanup.js` still needs a later clean removal or safe replacement pass
- root `auth.js` and root `account-access.js` still need final cleanup review
- backend cleanup of `api/get-dashboard-summary.js` and `api/get-user-listings.js` is still worthwhile as a follow-on hardening pass

Closes #36 (Bundle 6 portion).