### PR TITLE
Add dashboard nav alias hotfix for legacy section ids

### DIFF
--- a/bundle_d/dashboard.js
+++ b/bundle_d/dashboard.js
@@ -49,7 +49,8 @@
     "/dashboard-phase20-rc-hardening.js?v=20260411p20",
     "/dashboard-phase21-shell-repair.js?v=20260412p23",
     "/dashboard-phase23-bundle-c.js?v=20260412c1",
-    "/dashboard-bundle-d-ops.js?v=20260413d1"
+    "/dashboard-bundle-d-ops.js?v=20260413d1",
+    "/dashboard-nav-hotfix.js?v=20260512a1"
   ];
 
   let compatBootTriggered = false;

--- a/dashboard-nav-hotfix.js
+++ b/dashboard-nav-hotfix.js
@@ -1,0 +1,107 @@
+(() => {
+  if (window.__ELEVATE_DASHBOARD_NAV_HOTFIX__) return;
+  window.__ELEVATE_DASHBOARD_NAV_HOTFIX__ = true;
+
+  const NS = (window.ElevateDashboard = window.ElevateDashboard || {});
+
+  function clean(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+  }
+
+  function getSections() {
+    return Array.from(document.querySelectorAll('.dashboard-section')).filter(Boolean);
+  }
+
+  function desiredNavOrder() {
+    return ['overview', 'tools', 'analytics', 'compliance', 'partners', 'setup', 'billing'];
+  }
+
+  function aliasMap() {
+    return {
+      overview: ['overview', 'overviewSection', 'overview-section'],
+      tools: ['extension', 'extensionSection', 'extension-section', 'tools-panel'],
+      analytics: ['analytics', 'analyticsSection', 'analytics-section', 'tools', 'toolsSection', 'tools-section'],
+      compliance: ['compliance', 'complianceSection', 'compliance-section'],
+      partners: ['partners', 'partnersSection', 'partners-section', 'affiliate'],
+      setup: ['setup', 'setupSection', 'setup-section', 'profile'],
+      billing: ['billing', 'billingSection', 'billing-section']
+    };
+  }
+
+  function resolveSectionElement(sectionId) {
+    const requested = clean(sectionId);
+    if (!requested) return null;
+    const aliases = aliasMap()[requested] || [requested];
+    for (const id of aliases) {
+      const direct = document.getElementById(id);
+      if (direct) return direct;
+    }
+    const sections = getSections();
+    for (const id of aliases) {
+      const matched = sections.find((section) => clean(section.id) === clean(id));
+      if (matched) return matched;
+    }
+    return null;
+  }
+
+  function markActive(sectionId, sectionEl = null) {
+    const resolved = clean(sectionEl?.id || resolveSectionElement(sectionId)?.id || sectionId);
+    document.querySelectorAll('.sidebar-nav .nav-btn').forEach((button, index) => {
+      const key = clean(button.dataset.eaNavKey || desiredNavOrder()[index] || 'overview');
+      const buttonResolved = clean(resolveSectionElement(key)?.id || key);
+      button.classList.toggle('active', Boolean(resolved) && buttonResolved === resolved);
+    });
+  }
+
+  function patchedShowSection(sectionId, options = {}) {
+    const target = resolveSectionElement(sectionId);
+    const sections = getSections();
+    if (!sections.length || !target) return false;
+
+    sections.forEach((section) => {
+      section.style.display = section === target ? 'block' : 'none';
+    });
+
+    markActive(sectionId, target);
+    if (clean(target.id)) NS.state?.set?.('ui.activeSection', clean(target.id));
+
+    if (options.scroll !== false) {
+      try {
+        target.scrollIntoView({ block: 'start', behavior: options.behavior || 'auto' });
+      } catch {}
+    }
+    return true;
+  }
+
+  function bindSidebar() {
+    const nav = document.querySelector('.sidebar-nav');
+    if (!nav || nav.dataset.eaNavHotfixBound === 'true') return;
+    nav.dataset.eaNavHotfixBound = 'true';
+
+    nav.addEventListener('click', (event) => {
+      const button = event.target.closest('.nav-btn');
+      if (!button || !nav.contains(button)) return;
+      const buttons = Array.from(nav.querySelectorAll('.nav-btn')).filter(Boolean);
+      const index = buttons.indexOf(button);
+      const key = desiredNavOrder()[index] || clean(button.dataset.eaNavKey || 'overview');
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      patchedShowSection(key, { scroll: false });
+    }, true);
+  }
+
+  function boot() {
+    window.showSection = patchedShowSection;
+    bindSidebar();
+    const active = NS.state?.get?.('ui.activeSection') || 'overview';
+    patchedShowSection(active, { scroll: false });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', boot, { once: true });
+  } else {
+    boot();
+  }
+
+  window.addEventListener('load', boot);
+})();


### PR DESCRIPTION
## Summary
- add a nav routing hotfix that resolves current sidebar buttons against legacy dashboard section ids
- load the hotfix after the existing dashboard bundles so it becomes the final nav router
- preserve the current left-side nav structure and visual layout

## Problem
The first fix removed bundle D sidebar mutation, but the dashboard still has legacy section id mismatches underneath the current shell. The current nav order is modern, while some actual section ids still resolve through older ids like `extension`, `tools`, `profile`, and `affiliate`, causing Tools and Analytics to land on the wrong panels.

## Fix
- add `dashboard-nav-hotfix.js`
- map the live nav order to the correct legacy/current section ids
- override `window.showSection` with a final resolver that routes:
  - Command Centre -> overview
  - Tools -> extension
  - Analytics -> analytics/tools
  - Setup -> profile/setup
  - Partners -> affiliate/partners
- load the hotfix last from `bundle_d/dashboard.js`

## Expected result
- Command Centre opens Command Centre
- Tools opens Tools
- Analytics opens Analytics
- left nav structure stays unchanged
