### PR TITLE
Remove nav hotfix and use native dashboard UI routing

### DIFF
--- a/bundle_d/dashboard.js
+++ b/bundle_d/dashboard.js
@@ -9,7 +9,7 @@
 
   const MODULES = [
     "/dashboard-state.js?v=20260406p12a",
-    "/dashboard-ui.js?v=20260406p12a",
+    "/dashboard-ui.js?v=20260513c1",
     "/dashboard-api.js?v=20260406p12a",
     "/dashboard-overview.js?v=20260406p12a",
     "/dashboard-listings.js?v=20260406p12a",
@@ -49,8 +49,7 @@
     "/dashboard-phase20-rc-hardening.js?v=20260411p20",
     "/dashboard-phase21-shell-repair.js?v=20260412p23",
     "/dashboard-phase23-bundle-c.js?v=20260412c1",
-    "/dashboard-bundle-d-ops.js?v=20260413d1",
-    "/dashboard-nav-hotfix.js?v=20260512a1"
+    "/dashboard-bundle-d-ops.js?v=20260413d1"
   ];
 
   let compatBootTriggered = false;

--- a/dashboard-ui.js
+++ b/dashboard-ui.js
@@ -19,10 +19,10 @@
     return {
       reviewCenter: ["reviewCenter", "review-center", "review_center"],
       listings: ["listings", "listingSection", "listing-section"],
-      analytics: ["analytics", "analyticsSection", "analytics-section"],
+      analytics: ["analytics", "analyticsSection", "analytics-section", "tools", "toolsSection", "tools-section"],
       overview: ["overview", "overviewSection", "overview-section"],
       setup: ["setup", "setupSection", "setup-section", "profile"],
-      tools: ["tools", "toolsSection", "tools-section", "extension"],
+      tools: ["extension", "extensionSection", "extension-section", "toolsPanel", "tools-panel", "tools", "toolsSection", "tools-section"],
       compliance: ["compliance", "complianceSection", "compliance-section"],
       partners: ["partners", "partnersSection", "partners-section", "affiliate"],
       billing: ["billing", "billingSection", "billing-section"]
@@ -32,7 +32,6 @@
   function resolveSectionId(sectionId) {
     const requested = clean(sectionId);
     if (!requested) return requested;
-    if (document.getElementById(requested)) return requested;
     const aliases = sectionAliases();
     const candidates = aliases[requested] || [requested];
     return candidates.find((id) => document.getElementById(id)) || requested;


### PR DESCRIPTION
## Summary
- remove `dashboard-nav-hotfix.js` from the dashboard loader
- make `dashboard-ui.js` the only active sidebar router again
- update native section alias resolution so Tools and Analytics route correctly without the hotfix
- bump the `dashboard-ui.js` cache version in the loader

## Root cause
The last remaining blocker was `dashboard-nav-hotfix.js`. It still overrides `window.showSection`, and its alias map explicitly lets Analytics fall through to the tools section. That is why Tools started working while Analytics still opened Tools. fileciteturn61file0

## Fix
- remove `dashboard-nav-hotfix.js` from `bundle_d/dashboard.js`
- bump `dashboard-ui.js` loader version to `v=20260513c1`
- update native `dashboard-ui.js` alias handling so:
  - Tools prefers the extension surface
  - Analytics still resolves analytics first, with legacy tolerance only inside native UI routing

## Expected result
- Command Centre opens Command Centre
- Tools opens Tools
- Analytics opens Analytics
- left nav structure remains unchanged
