### PR TITLE
Fix analytics routing with dedicated section and cache bust

### DIFF
--- a/bundle_d/dashboard.js
+++ b/bundle_d/dashboard.js
@@ -9,13 +9,13 @@
 
   const MODULES = [
     "/dashboard-state.js?v=20260406p12a",
-    "/dashboard-ui.js?v=20260513c1",
+    "/dashboard-ui.js?v=20260513d2",
     "/dashboard-api.js?v=20260406p12a",
     "/dashboard-overview.js?v=20260406p12a",
     "/dashboard-listings.js?v=20260406p12a",
     "/dashboard-profile.js?v=20260406p12a",
     "/dashboard-tools.js?v=20260406p12a",
-    "/dashboard-analytics.js?v=20260413d1",
+    "/dashboard-analytics.js?v=20260513d2",
     "/dashboard-affiliate.js?v=20260406p12a",
     "/dashboard-billing.js?v=20260406p12a",
     "/dashboard-legacy.js?v=20260406p12a",

--- a/dashboard-analytics.js
+++ b/dashboard-analytics.js
@@ -33,14 +33,31 @@
     document.head.appendChild(style);
   }
 
+  function ensureAnalyticsSection(){
+    const mainInner = document.querySelector('.main-inner');
+    if (!mainInner) return null;
+
+    let analyticsSection = document.getElementById('analytics');
+    if (!analyticsSection) {
+      analyticsSection = document.createElement('section');
+      analyticsSection.id = 'analytics';
+      analyticsSection.className = 'dashboard-section';
+      mainInner.appendChild(analyticsSection);
+    }
+
+    return analyticsSection;
+  }
+
   function mountRoot(){
-    const tools = document.getElementById('tools');
-    if(!tools) return null;
+    const analyticsSection = ensureAnalyticsSection();
+    if(!analyticsSection) return null;
     let root = document.getElementById('eaRootG');
     if(!root){
       root = document.createElement('div');
       root.id = 'eaRootG';
-      tools.appendChild(root);
+      analyticsSection.appendChild(root);
+    } else if (!analyticsSection.contains(root)) {
+      analyticsSection.appendChild(root);
     }
     return root;
   }
@@ -165,5 +182,5 @@
   NS.analyticsWorkspace = { render };
 
   window.addEventListener('load', render);
-  window.addEventListener('elevate:tracking-refreshed', bindSegment);
+  window.addEventListener('elevate:tracking-refreshed', render);
 })();

--- a/dashboard-ui.js
+++ b/dashboard-ui.js
@@ -19,7 +19,7 @@
     return {
       reviewCenter: ["reviewCenter", "review-center", "review_center"],
       listings: ["listings", "listingSection", "listing-section"],
-      analytics: ["analytics", "analyticsSection", "analytics-section", "tools", "toolsSection", "tools-section"],
+      analytics: ["analytics", "analyticsSection", "analytics-section", "analyticsWorkspace"],
       overview: ["overview", "overviewSection", "overview-section"],
       setup: ["setup", "setupSection", "setup-section", "profile"],
       tools: ["extension", "extensionSection", "extension-section", "toolsPanel", "tools-panel", "tools", "toolsSection", "tools-section"],


### PR DESCRIPTION
## Summary
- separate analytics routing from tools aliases in `dashboard-ui.js`
- create and mount a dedicated `#analytics` dashboard section in `dashboard-analytics.js`
- move the analytics workspace root into that dedicated section instead of appending it under tools
- bust both `dashboard-ui.js` and `dashboard-analytics.js` cache keys in the loader

## Root cause sweep
This issue had two blockers working together:

1. Native UI routing still allowed Analytics to resolve to Tools because analytics aliases still included tools-style ids.
2. The analytics workspace itself was mounted inside `#tools`, so even when analytics UI existed, it physically lived under the Tools section. That made Analytics routing collapse back into Tools behavior.

## Fix
- `dashboard-ui.js`
  - remove tools fallthrough from analytics aliases
  - add `analyticsWorkspace` as a valid analytics target
- `dashboard-analytics.js`
  - ensure a dedicated `section#analytics.dashboard-section` exists
  - mount `#eaRootG` into `#analytics` instead of `#tools`
- `bundle_d/dashboard.js`
  - bump `dashboard-ui.js` and `dashboard-analytics.js` versions to `v=20260513d2`

## Expected result
- Command Centre opens Command Centre
- Tools opens Tools only
- Analytics opens Analytics only
- left nav structure remains unchanged
