### PR TITLE
Fix Execution Hub cleanup so the layout changes actually apply

### DIFF
--- a/dashboard-execution-hub-cleanup.js
+++ b/dashboard-execution-hub-cleanup.js
@@ -4,11 +4,8 @@
 
   const CSS = `
     #executionHubV2Shell{gap:16px}
-    #executionHubV2Shell .xh-module-band{order:-20}
-    #executionHubV2Shell .xh-hero-grid{order:-10}
-    #executionHubV2Shell .xh-module-band{grid-template-columns:minmax(0,1fr) minmax(320px,.85fr);padding:18px 20px}
-    #executionHubV2Shell .xh-module-band h2{font-size:28px;margin-bottom:6px}
-    #executionHubV2Shell .xh-module-band-copy{font-size:14px}
+    #executionHubV2Shell .xh-hero-grid{order:2}
+    #executionHubV2Shell .xh-module-card{order:3}
     #executionHubV2Shell .xh-primary-card{padding:20px}
     #executionHubV2Shell .xh-side-card{padding:18px}
     #executionHubV2Shell .xh-title-row{margin-bottom:10px}
@@ -24,9 +21,19 @@
     #executionHubV2Shell .xh-action-card,
     #executionHubV2Shell .xh-blocker-card,
     #executionHubV2Shell .xh-activity-card{padding:16px}
-    #extension > *:not(#executionHubV2Shell):not(.main-header){display:none !important}
+    .execution-hub-cleanup-band{order:1;display:grid;grid-template-columns:minmax(0,1fr) minmax(320px,.85fr);gap:16px;align-items:end;background:#121212;border:1px solid rgba(212,175,55,.14);border-radius:22px;padding:18px 20px;box-shadow:0 10px 30px rgba(0,0,0,.28)}
+    .execution-hub-cleanup-band h2{font-size:28px;line-height:1.06;margin-bottom:6px}
+    .execution-hub-cleanup-band-copy{color:#a9a9a9;line-height:1.55;max-width:760px}
+    .execution-hub-cleanup-select-wrap{display:grid;gap:8px;min-width:280px}
+    .execution-hub-cleanup-select-wrap label{font-size:12px;color:#d4af37;font-weight:800;letter-spacing:1.3px;text-transform:uppercase}
+    .execution-hub-cleanup-select-row{display:flex;gap:12px;align-items:center;justify-content:flex-end;flex-wrap:wrap}
+    .execution-hub-cleanup-select-row .xh-module-select{min-width:280px}
+    #executionHubV2Shell .xh-module-select-row{display:none !important}
+    #extension .card,
+    #extension [class*="extension-"]{ }
+    .execution-hub-hide-legacy{display:none !important}
     @media (max-width: 1200px){
-      #executionHubV2Shell .xh-module-band{grid-template-columns:1fr}
+      .execution-hub-cleanup-band{grid-template-columns:1fr}
     }
   `;
 
@@ -70,32 +77,90 @@
     });
   }
 
-  function moveModuleBandFirst() {
+  function buildTopModuleBand() {
     const shell = document.getElementById('executionHubV2Shell');
-    const band = shell?.querySelector('.xh-module-band');
-    const hero = shell?.querySelector('.xh-hero-grid');
-    if (!shell || !band || !hero) return;
-    if (shell.firstElementChild !== band) shell.insertBefore(band, shell.firstElementChild);
-    const primaryTitle = hero.querySelector('.xh-title-row h2');
-    if (primaryTitle && /execution hub/i.test(primaryTitle.textContent)) {
-      primaryTitle.textContent = 'Post next vehicle';
+    if (!shell) return;
+
+    let band = document.getElementById('executionHubCleanupBand');
+    const sourceSelect = shell.querySelector('#executionHubModuleSelect');
+    const sourceStatus = shell.querySelector('.xh-workspace-head .xh-module-status') || shell.querySelector('.xh-module-status');
+    if (!sourceSelect) return;
+
+    if (!band) {
+      band = document.createElement('div');
+      band.id = 'executionHubCleanupBand';
+      band.className = 'execution-hub-cleanup-band';
+      band.innerHTML = `
+        <div>
+          <div class="xh-eyebrow">Execution Module</div>
+          <h2>Execution Hub</h2>
+          <div class="execution-hub-cleanup-band-copy">Select the execution layer you want to view. Vehicle Poster remains the live flagship tool.</div>
+        </div>
+        <div class="execution-hub-cleanup-select-wrap">
+          <label for="executionHubModuleSelectClone">Execution Module</label>
+          <div class="execution-hub-cleanup-select-row">
+            <select id="executionHubModuleSelectClone" class="xh-module-select"></select>
+            <div class="xh-module-status" id="executionHubCleanupStatus">Live Now</div>
+          </div>
+        </div>
+      `;
+      shell.prepend(band);
     }
+
+    const clone = band.querySelector('#executionHubModuleSelectClone');
+    clone.innerHTML = sourceSelect.innerHTML;
+    clone.value = sourceSelect.value;
+    const status = band.querySelector('#executionHubCleanupStatus');
+    if (status && sourceStatus) status.textContent = clean(sourceStatus.textContent || 'Live Now');
+
+    if (clone.dataset.boundCleanup !== 'true') {
+      clone.dataset.boundCleanup = 'true';
+      clone.addEventListener('change', () => {
+        sourceSelect.value = clone.value;
+        sourceSelect.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
+  }
+
+  function simplifyHero() {
+    const shell = document.getElementById('executionHubV2Shell');
+    if (!shell) return;
+    const hero = shell.querySelector('.xh-hero-grid');
+    if (!hero) return;
+    const title = hero.querySelector('.xh-title-row h2');
+    if (title && /execution hub/i.test(title.textContent)) title.textContent = 'Post next vehicle';
+  }
+
+  function hideLegacyCards() {
+    const section = document.getElementById('extension');
+    if (!section) return;
+    Array.from(section.querySelectorAll('.card')).forEach((card) => {
+      if (card.closest('#executionHubV2Shell')) return;
+      card.classList.add('execution-hub-hide-legacy');
+    });
+    Array.from(section.children).forEach((child) => {
+      if (child.id === 'executionHubV2Shell') return;
+      if (child.classList?.contains('main-header')) return;
+      if (child.matches?.('.card')) child.classList.add('execution-hub-hide-legacy');
+    });
   }
 
   function enhance() {
     ensureStyle();
     relabelHeaderAndNav();
-    moveModuleBandFirst();
+    buildTopModuleBand();
+    simplifyHero();
+    hideLegacyCards();
   }
 
   NS.modules = NS.modules || {};
   NS.modules.executionHubCleanup = true;
-  window.addEventListener('load', () => setTimeout(enhance, 60));
-  window.addEventListener('elevate:tracking-refreshed', () => setTimeout(enhance, 60));
-  window.addEventListener('elevate:summary-ready', () => setTimeout(enhance, 60));
+  window.addEventListener('load', () => setTimeout(enhance, 80));
+  window.addEventListener('elevate:tracking-refreshed', () => setTimeout(enhance, 80));
+  window.addEventListener('elevate:summary-ready', () => setTimeout(enhance, 80));
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => setTimeout(enhance, 60), { once: true });
+    document.addEventListener('DOMContentLoaded', () => setTimeout(enhance, 80), { once: true });
   } else {
-    setTimeout(enhance, 60);
+    setTimeout(enhance, 80);
   }
 })();


### PR DESCRIPTION
## Summary
- fix the cleanup layer so it actually applies to the live DOM structure
- build a real top Execution Module band instead of assuming one already exists
- sync the top selector to the live module selector
- keep forcing the Execution Hub header and locked side-nav naming
- hide the remaining legacy cards and redundant lower surfaces

## Root cause
The previous cleanup pass loaded successfully, but it was targeting structure that did not actually exist in the live base shell. In particular, it assumed a `.xh-module-band` was already present, so the reordering logic never materially changed the page. The CSS also depended on hiding elements that were not enough by themselves to change the layout in the way intended.

## Fix
- create a real top module band in the cleanup layer
- clone and sync the live execution module selector into that band
- keep the hero simplified and relabeled
- hard-hide the remaining legacy cards outside the new shell
- preserve the runtime relabeling for Execution Hub and the locked side-nav naming system

## Expected result
- Execution Module appears higher
- page reads cleaner and less crowded
- redundant bottom cards stop surfacing
- Execution Hub actually looks different from before instead of appearing unchanged
