### PR TITLE
Wire native Execution Hub into the actual live dashboard loader

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -12,11 +12,11 @@
   const MODULES = [
     "/dashboard-state.js?v=20260406p12a",
     "/dashboard-ui.js?v=20260406p12a",
+    "/dashboard-section-governor.js?v=20260513live1",
     "/dashboard-api.js?v=20260406p12a",
     "/dashboard-overview.js?v=20260512cc3",
     "/dashboard-listings.js?v=20260406p12a",
     "/dashboard-profile.js?v=20260406p12a",
-    "/dashboard-tools.js?v=20260406p12a",
     "/dashboard-analytics.js?v=20260412p22e",
     "/dashboard-affiliate.js?v=20260406p12a",
     "/dashboard-billing.js?v=20260406p12a",


### PR DESCRIPTION
## Summary
- fix the actual live dashboard path instead of the unused `bundle_d/dashboard.js` path
- load `dashboard-section-governor.js` from `/dashboard.js`, which is the script `dashboard.html` actually uses
- remove the legacy `dashboard-tools.js` renderer from the active live loader
- cache-bust the native section governor asset so production requests the updated file

## Root cause
The previous passes were modifying `bundle_d/dashboard.js`, but the live `dashboard.html` does not load that file. It loads `/dashboard.js?v=20260401h`.

Because of that, the browser kept using the old live loader, which still loaded `dashboard-tools.js` and ignored the new native Execution Hub ownership path.

## Fix
Updated `/dashboard.js` so the live module chain now loads:
- `dashboard-section-governor.js?v=20260513live1`

and no longer loads:
- `dashboard-tools.js`

## Expected result
The live dashboard should finally use the native Execution Hub renderer path because the actual active loader now includes the section governor and excludes the old Tools renderer.

## Follow-up
The static legacy markup inside `dashboard.html` still exists as fallback markup, but with the actual loader now fixed, the native governor should replace the `extension` section after load. If needed, the next cleanup pass can reduce that fallback markup once we confirm the live path is responding.